### PR TITLE
Alt prevents or releases Shift

### DIFF
--- a/qtkeypadbridge.cpp
+++ b/qtkeypadbridge.cpp
@@ -193,27 +193,19 @@ void keyToKeypad(QKeyEvent *event)
     {
         auto mkey = event->key();
 
-        // Compose alt into the unused bit of the keycode
+        if (event->modifiers() & Qt::ShiftModifier && mkey == Qt::Key_Alt)
+        {
+            std::cout << "Here" << std::endl;
+            setKeypad(keymap::shift, false);
+            return;
+        }
+
         if (event->modifiers() & Qt::AltModifier)
         {
-            if (event->modifiers() & Qt::ShiftModifier)
-            {
-                if (mkey == Qt::Key_Alt)
-                {
-                    // Release Shift and return
-                    auto pressed = pressed_keys.find(Qt::Key_Shift);
-
-                    if (pressed != pressed_keys.end())
-                    {
-                        setKeypad(*pressed, false);
-                        pressed_keys.erase(pressed);
-                    }
-                    return;
-                }
-                else if (mkey == Qt::Key_Shift)
-                    return; // Just ignore it
-            }
-            mkey |= ALT;
+            if (mkey == Qt::Key_Shift)
+                return; // Just ignore it
+            else
+                mkey |= ALT; // Compose alt into the unused bit of the keycode
         }
 
         auto translated = QtKeyMap.find(mkey);

--- a/qtkeypadbridge.cpp
+++ b/qtkeypadbridge.cpp
@@ -82,12 +82,17 @@ void keyToKeypad(QKeyEvent *event)
         ,{Qt::Key_Y, keymap::ay}
         ,{Qt::Key_Z, keymap::az}
         ,{Qt::Key_Less, keymap::ee}
+        ,{Qt::Key_Less | ALT, keymap::ee}
         ,{Qt::Key_E | ALT, keymap::ee}
         ,{Qt::Key_Bar, keymap::pi}
+        ,{Qt::Key_Bar | ALT, keymap::pi}
         ,{Qt::Key_Comma, keymap::comma}
+        ,{Qt::Key_Comma | ALT, keymap::comma}
         ,{Qt::Key_Question, keymap::punct}
+        ,{Qt::Key_Question | ALT, keymap::punct}
         ,{Qt::Key_W | ALT, keymap::punct}
         ,{Qt::Key_Greater, keymap::flag}
+        ,{Qt::Key_Greater | ALT, keymap::flag}
         ,{Qt::Key_F | ALT, keymap::flag}
         ,{Qt::Key_Space, keymap::space}
         ,{Qt::Key_Enter | ALT, keymap::ret}
@@ -105,40 +110,57 @@ void keyToKeypad(QKeyEvent *event)
         ,{Qt::Key_8, keymap::n8}
         ,{Qt::Key_9, keymap::n9}
         ,{Qt::Key_Period, keymap::dot}
+        ,{Qt::Key_Period | ALT, keymap::dot}
         ,{Qt::Key_Minus | ALT, keymap::neg}
         ,{Qt::Key_QuoteLeft, keymap::neg}
+        ,{Qt::Key_QuoteLeft | ALT, keymap::neg}
 
             // Left buttons
         ,{Qt::Key_Equal, keymap::equ}
+        ,{Qt::Key_Equal | ALT, keymap::equ}
         ,{Qt::Key_Q | ALT, keymap::equ}
         ,{Qt::Key_Backslash, keymap::trig}
+        ,{Qt::Key_Backslash | ALT, keymap::trig}
         ,{Qt::Key_T | ALT, keymap::trig}
         ,{Qt::Key_AsciiCircum, keymap::pow}
+        ,{Qt::Key_AsciiCircum | ALT, keymap::pow}
         ,{Qt::Key_P | ALT, keymap::pow}
         ,{Qt::Key_At, keymap::squ}
+        ,{Qt::Key_At | ALT, keymap::squ}
         ,{Qt::Key_2 | ALT, keymap::squ}
         ,{Qt::Key_BracketLeft, keymap::exp}
+        ,{Qt::Key_BracketLeft | ALT, keymap::exp}
         ,{Qt::Key_X | ALT, keymap::exp}
         ,{Qt::Key_BracketRight, keymap::pow10}
+        ,{Qt::Key_BracketRight | ALT, keymap::pow10}
         ,{Qt::Key_1 | ALT, keymap::pow10}
         ,{Qt::Key_ParenLeft, keymap::pleft}
+        ,{Qt::Key_ParenLeft | ALT, keymap::pleft}
         ,{Qt::Key_F1, keymap::pleft}
         ,{Qt::Key_ParenRight, keymap::pright}
+        ,{Qt::Key_ParenRight | ALT, keymap::pright}
         ,{Qt::Key_F2, keymap::pright}
 
             // Right buttons
         ,{Qt::Key_Semicolon, keymap::metrix}
+        ,{Qt::Key_Semicolon | ALT, keymap::metrix}
         ,{Qt::Key_O | ALT, keymap::metrix}
         ,{Qt::Key_Apostrophe, keymap::cat}
+        ,{Qt::Key_Apostrophe | ALT, keymap::cat}
         ,{Qt::Key_C | ALT, keymap::cat}
         ,{Qt::Key_Asterisk, keymap::mult}
+        ,{Qt::Key_Asterisk | ALT, keymap::mult}
         ,{Qt::Key_A | ALT, keymap::mult}
         ,{Qt::Key_Slash, keymap::div}
+        ,{Qt::Key_Slash | ALT, keymap::div}
         ,{Qt::Key_F3, keymap::div}
         ,{Qt::Key_Plus, keymap::plus}
+        ,{Qt::Key_Plus | ALT, keymap::plus}
         ,{Qt::Key_Equal | ALT, keymap::plus}
         ,{Qt::Key_Minus, keymap::minus}
+        ,{Qt::Key_Minus | ALT, keymap::minus}
         ,{Qt::Key_Underscore, keymap::minus}
+        ,{Qt::Key_Underscore | ALT, keymap::minus}
         ,{Qt::Key_Enter, keymap::enter}
         ,{Qt::Key_Return, keymap::enter}
     };
@@ -173,7 +195,26 @@ void keyToKeypad(QKeyEvent *event)
 
         // Compose alt into the unused bit of the keycode
         if (event->modifiers() & Qt::AltModifier)
+        {
+            if (event->modifiers() & Qt::ShiftModifier)
+            {
+                if (mkey == Qt::Key_Alt)
+                {
+                    // Release Shift and return
+                    auto pressed = pressed_keys.find(Qt::Key_Shift);
+
+                    if (pressed != pressed_keys.end())
+                    {
+                        setKeypad(*pressed, false);
+                        pressed_keys.erase(pressed);
+                    }
+                    return;
+                }
+                else if (mkey == Qt::Key_Shift)
+                    return; // Just ignore it
+            }
             mkey |= ALT;
+        }
 
         auto translated = QtKeyMap.find(mkey);
 

--- a/qtkeypadbridge.cpp
+++ b/qtkeypadbridge.cpp
@@ -195,7 +195,6 @@ void keyToKeypad(QKeyEvent *event)
 
         if (event->modifiers() & Qt::ShiftModifier && mkey == Qt::Key_Alt)
         {
-            std::cout << "Here" << std::endl;
             setKeypad(keymap::shift, false);
             return;
         }


### PR DESCRIPTION
Makes "Alt + Shift + " key combinations possible.

There is a catch though. If you press Shift before Alt, it's going to release the Shift which is interpreted by calc as some type of "one time shift lock". So:
Shift + 9 = Shift + (
Shift + Alt + 9 = [Shift is released, but maybe on one-time-lock] + (
Alt + Shift + 9 = (

I don't know if nspire-io exhibits the same behavior, but it is something to keep in mind when testing.