### PR TITLE
Forced PIE disabling for Archlinux

### DIFF
--- a/firebird.pro
+++ b/firebird.pro
@@ -40,7 +40,7 @@ LIBS += -lz
 # Override bad default options to enable better optimizations
 QMAKE_CFLAGS_RELEASE = -O3 -flto
 QMAKE_CXXFLAGS_RELEASE = -O3 -flto
-QMAKE_LFLAGS_RELEASE = -Wl,-O3 -flto -fno-pie
+QMAKE_LFLAGS_RELEASE = -Wl,-O3 -flto
 QMAKE_LFLAGS += -fno-pie
 
 # Apple's clang doesn't know about this one

--- a/firebird.pro
+++ b/firebird.pro
@@ -40,7 +40,7 @@ LIBS += -lz
 # Override bad default options to enable better optimizations
 QMAKE_CFLAGS_RELEASE = -O3 -flto
 QMAKE_CXXFLAGS_RELEASE = -O3 -flto
-QMAKE_LFLAGS_RELEASE = -Wl,-O3 -flto
+QMAKE_LFLAGS_RELEASE = -Wl,-O3 -flto -fno-pie
 
 # Apple's clang doesn't know about this one
 macx: QMAKE_LFLAGS_RELEASE -= -Wl,-O3

--- a/firebird.pro
+++ b/firebird.pro
@@ -41,6 +41,7 @@ LIBS += -lz
 QMAKE_CFLAGS_RELEASE = -O3 -flto
 QMAKE_CXXFLAGS_RELEASE = -O3 -flto
 QMAKE_LFLAGS_RELEASE = -Wl,-O3 -flto -fno-pie
+QMAKE_LFLAGS += -fno-pie
 
 # Apple's clang doesn't know about this one
 macx: QMAKE_LFLAGS_RELEASE -= -Wl,-O3


### PR DESCRIPTION
To avoid crashing on x86_64 Archlinux distros. Looks like it's enabled by default.