### PR TITLE
Check for -no-pie linker flag, and use it if available

### DIFF
--- a/config.tests/-no-pie/test.c
+++ b/config.tests/-no-pie/test.c
@@ -1,0 +1,1 @@
+int main(void){}

--- a/config.tests/-no-pie/test.pro
+++ b/config.tests/-no-pie/test.pro
@@ -1,0 +1,2 @@
+SOURCES = test.c
+QMAKE_LFLAGS += -no-pie

--- a/firebird.pro
+++ b/firebird.pro
@@ -1,3 +1,5 @@
+load(configure)
+
 lessThan(QT_MAJOR_VERSION, 5): error("You need at least Qt 5.6 to build firebird!")
 lessThan(QT_MINOR_VERSION, 6): error("You need at least Qt 5.6 to build firebird!")
 
@@ -43,6 +45,8 @@ QMAKE_CFLAGS_RELEASE = -O3 -flto
 QMAKE_CXXFLAGS_RELEASE = -O3 -flto
 QMAKE_LFLAGS_RELEASE = -Wl,-O3 -flto
 QMAKE_LFLAGS += -fno-pie
+
+*-g++*: qtCompileTest(-no-pie): QMAKE_LFLAGS += -no-pie
 
 # Apple's clang doesn't know about this one
 macx: QMAKE_LFLAGS_RELEASE -= -Wl,-O3


### PR DESCRIPTION
This seems to be the proper qmake way to do it. It should now work on PIE-default toolchains, as well as older versions of GCC that don't have the -no-pie flag.