### PR TITLE
Use QFileInfo's basename for QMLBridge::basename

### DIFF
--- a/qmlbridge.cpp
+++ b/qmlbridge.cpp
@@ -298,10 +298,7 @@ QString QMLBridge::basename(QString path)
     if(path.isEmpty())
         return tr("None");
 
-    std::string pathname = path.toStdString();
-    return QString::fromStdString(std::string(
-                std::find_if(pathname.rbegin(), pathname.rend(), [=](char c) { return c == '/'; }).base(),
-                                      pathname.end()));
+    return QFileInfo(path).fileName();
 }
 
 QUrl QMLBridge::dir(QString path)


### PR DESCRIPTION
In particular, this solves a crash on iOS arm64 (at least with ASan, since it detects a stack buffer overflow: https://www.irccloud.com/pastebin/kzGtT07x/)