### PR TITLE
Set the EnableHiDPIScaling attribute

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -69,6 +69,8 @@ int main(int argc, char **argv)
 {
     #ifdef Q_OS_ANDROID
         QGuiApplication::setAttribute(Qt::AA_DisableHighDpiScaling);
+    #else
+        QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     #endif
     QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 


### PR DESCRIPTION
Necessary to make it work properly on non-Plasma DEs, #148.

Needs verification on macOS and iOS which have their own scaling options.