### PR TITLE
Don't use LTO with clang

### DIFF
--- a/firebird.pro
+++ b/firebird.pro
@@ -1,4 +1,4 @@
-!macx: !ios: load(configure)
+!clang: load(configure)
 
 lessThan(QT_MAJOR_VERSION, 5): error("You need at least Qt 5.6 to build firebird!")
 equals(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 6): error("You need at least Qt 5.6 to build firebird!")
@@ -44,9 +44,12 @@ LIBS += -lz
 QMAKE_CFLAGS_RELEASE = -O3 -flto -DNDEBUG
 QMAKE_CXXFLAGS_RELEASE = -O3 -flto -DNDEBUG
 QMAKE_LFLAGS_RELEASE = -Wl,-O3 -flto
-QMAKE_LFLAGS += -fno-pie
 
-*-g++*: qtCompileTest(-no-pie): QMAKE_LFLAGS += -no-pie
+# Don't build a position independent executable, not compatible with the JIT
+equals(TRANSLATION_ENABLED, true) {
+    clang: QMAKE_LFLAGS += -nopie
+    else: qtCompileTest(-no-pie): QMAKE_LFLAGS += -no-pie
+}
 
 # Apple's clang doesn't know about this one
 macx: QMAKE_LFLAGS_RELEASE -= -Wl,-O3
@@ -56,7 +59,6 @@ macx|ios: QMAKE_CXXFLAGS += -stdlib=libc++
 
 # On non-macOS the linker can't deal with LLVM bitcode directly (missing plugin?)
 clang:!macx {
-    QMAKE_LFLAGS -= -fno-pie
     QMAKE_CFLAGS_RELEASE -= -flto
     QMAKE_CXXFLAGS_RELEASE -= -flto
     QMAKE_LFLAGS_RELEASE -= -Wl,-O3 -flto

--- a/firebird.pro
+++ b/firebird.pro
@@ -46,16 +46,10 @@ QMAKE_CXXFLAGS_RELEASE = -O3 -DNDEBUG
 
 # Don't enable LTO with clang on Linux, incompatible with Qt (QTBUG-43556).
 !clang | !linux: {
-    # With the iOS toolchain, LTO appears to be broken due to a missing linker plugin.
-    !ios {
-        QMAKE_CFLAGS_RELEASE += -flto
-        QMAKE_CXXFLAGS_RELEASE += -flto
-        QMAKE_LFLAGS_RELEASE += -flto
-    }
+    QMAKE_CFLAGS_RELEASE += -flto
+    QMAKE_CXXFLAGS_RELEASE += -flto
+    QMAKE_LFLAGS_RELEASE += -flto
 }
-
-# This became needed, somehow.
-macx|ios: QMAKE_CXXFLAGS += -stdlib=libc++
 
 # noexecstack is not supported by MinGW's as
 !win32 {

--- a/firebird.pro
+++ b/firebird.pro
@@ -41,22 +41,21 @@ QMAKE_CXXFLAGS += -g -std=c++11 -Wall -Wextra -D QT_NO_CAST_FROM_ASCII
 LIBS += -lz
 
 # Override bad default options to enable better optimizations
-QMAKE_CFLAGS_RELEASE = -O3 -flto -DNDEBUG
-QMAKE_CXXFLAGS_RELEASE = -O3 -flto -DNDEBUG
-QMAKE_LFLAGS_RELEASE = -Wl,-O3 -flto
+QMAKE_CFLAGS_RELEASE = -O3 -DNDEBUG
+QMAKE_CXXFLAGS_RELEASE = -O3 -DNDEBUG
 
-# Apple's clang doesn't know about this one
-macx: QMAKE_LFLAGS_RELEASE -= -Wl,-O3
+# Don't enable LTO with clang on Linux, incompatible with Qt (QTBUG-43556).
+!clang | !linux: {
+    # With the iOS toolchain, LTO appears to be broken due to a missing linker plugin.
+    !ios {
+        QMAKE_CFLAGS_RELEASE += -flto
+        QMAKE_CXXFLAGS_RELEASE += -flto
+        QMAKE_LFLAGS_RELEASE += -flto
+    }
+}
 
 # This became needed, somehow.
 macx|ios: QMAKE_CXXFLAGS += -stdlib=libc++
-
-# On non-macOS the linker can't deal with LLVM bitcode directly (missing plugin?)
-clang:!macx {
-    QMAKE_CFLAGS_RELEASE -= -flto
-    QMAKE_CXXFLAGS_RELEASE -= -flto
-    QMAKE_LFLAGS_RELEASE -= -Wl,-O3 -flto
-}
 
 # noexecstack is not supported by MinGW's as
 !win32 {

--- a/firebird.pro
+++ b/firebird.pro
@@ -45,12 +45,6 @@ QMAKE_CFLAGS_RELEASE = -O3 -flto -DNDEBUG
 QMAKE_CXXFLAGS_RELEASE = -O3 -flto -DNDEBUG
 QMAKE_LFLAGS_RELEASE = -Wl,-O3 -flto
 
-# Don't build a position independent executable, not compatible with the JIT
-equals(TRANSLATION_ENABLED, true) {
-    clang: QMAKE_LFLAGS += -nopie
-    else: qtCompileTest(-no-pie): QMAKE_LFLAGS += -no-pie
-}
-
 # Apple's clang doesn't know about this one
 macx: QMAKE_LFLAGS_RELEASE -= -Wl,-O3
 
@@ -134,6 +128,12 @@ equals(TRANSLATION_ENABLED, true) {
 
     ASMCODE = $$join(FB_ARCH, "", "core/asmcode_", ".S")
     exists($$ASMCODE): ASMCODE_IMPL = $$ASMCODE
+
+    # Don't build a position independent executable, not compatible with the x86 and x86_64 JITs.
+    equals(FB_ARCH, "x86") | equals(FB_ARCH, "x86_64")  {
+        clang: QMAKE_LFLAGS += -nopie
+        else: qtCompileTest(-no-pie): QMAKE_LFLAGS += -no-pie
+    }
 }
 else: DEFINES += NO_TRANSLATION
 


### PR DESCRIPTION
- Disabling LTO for just the UI does not seem to work with qmake, so just
  disable it completely with clang.

Depends on #167