### PR TITLE
Support native Android file picker used by Qt >= 5.13

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0"?>
 <manifest package="org.firebird.emu" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="1.4" android:versionCode="8" android:installLocation="auto">
-    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="Firebird Emu" android:icon="@drawable/icon">
+    <application android:hardwareAccelerated="true" android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="Firebird Emu" android:icon="@drawable/icon" android:extractNativeLibs="true">
         <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation" android:name="org.qtproject.qt5.android.bindings.QtActivity" android:label="-- %%INSERT_APP_NAME%% --" android:screenOrientation="unspecified" android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+
             <meta-data android:name="android.app.lib_name" android:value="-- %%INSERT_APP_LIB_NAME%% --"/>
             <meta-data android:name="android.app.qt_sources_resource_id" android:resource="@array/qt_sources"/>
             <meta-data android:name="android.app.repository" android:value="default"/>
@@ -13,11 +14,10 @@
             <meta-data android:name="android.app.bundled_libs_resource_id" android:resource="@array/bundled_libs"/>
             <!-- Deploy Qt libs as part of package -->
             <meta-data android:name="android.app.bundle_local_qt_libs" android:value="-- %%BUNDLE_LOCAL_QT_LIBS%% --"/>
-            <meta-data android:name="android.app.bundled_in_lib_resource_id" android:resource="@array/bundled_in_lib"/>
-            <meta-data android:name="android.app.bundled_in_assets_resource_id" android:resource="@array/bundled_in_assets"/>
             <!-- Run with local libs -->
             <meta-data android:name="android.app.use_local_qt_libs" android:value="-- %%USE_LOCAL_QT_LIBS%% --"/>
             <meta-data android:name="android.app.libs_prefix" android:value="/data/local/tmp/qt/"/>
+            <meta-data android:name="android.app.load_local_libs_resource_id" android:resource="@array/load_local_libs"/>
             <meta-data android:name="android.app.load_local_libs" android:value="-- %%INSERT_LOCAL_LIBS%% --"/>
             <meta-data android:name="android.app.load_local_jars" android:value="-- %%INSERT_LOCAL_JARS%% --"/>
             <meta-data android:name="android.app.static_init_classes" android:value="-- %%INSERT_INIT_CLASSES%% --"/>

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -40,7 +40,7 @@
             <meta-data android:name="android.max_aspect" android:value="2.5"/>
         </activity>
     </application>
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="16"/>
+    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="21"/>
     <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true"/>
 
     <!-- The following comment will be replaced upon deployment with default permissions based on the dependencies of the application.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,23 +1,23 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:3.5.0'
     }
 }
 
-allprojects {
-    repositories {
-        jcenter()
-    }
+repositories {
+    google()
+    jcenter()
 }
 
 apply plugin: 'com.android.application'
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
 }
 
 android {
@@ -44,7 +44,7 @@ android {
             java.srcDirs = [qt5AndroidDir + '/src', 'src', 'java']
             aidl.srcDirs = [qt5AndroidDir + '/src', 'src', 'aidl']
             res.srcDirs = [qt5AndroidDir + '/res', 'res']
-            resources.srcDirs = ['src']
+            resources.srcDirs = ['resources']
             renderscript.srcDirs = ['src']
             assets.srcDirs = ['assets']
             jniLibs.srcDirs = ['libs']
@@ -53,5 +53,10 @@ android {
 
     lintOptions {
         abortOnError false
+    }
+
+    // Do not compress Qt binary resources file
+    aaptOptions {
+        noCompress 'rcc'
     }
 }

--- a/android/res/values/libs.xml
+++ b/android/res/values/libs.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
     <array name="qt_sources">
-        <item>https://download.qt.io/ministro/android/qt5/qt-5.7</item>
+        <item>https://download.qt.io/ministro/android/qt5/qt-5.14</item>
     </array>
 
     <!-- The following is handled automatically by the deployment tool. It should
@@ -11,15 +11,12 @@
         <!-- %%INSERT_EXTRA_LIBS%% -->
     </array>
 
-     <array name="qt_libs">
-         <!-- %%INSERT_QT_LIBS%% -->
-     </array>
-
-    <array name="bundled_in_lib">
-        <!-- %%INSERT_BUNDLED_IN_LIB%% -->
+    <array name="qt_libs">
+        <!-- %%INSERT_QT_LIBS%% -->
     </array>
-    <array name="bundled_in_assets">
-        <!-- %%INSERT_BUNDLED_IN_ASSETS%% -->
+
+    <array name="load_local_libs">
+        <!-- %%INSERT_LOCAL_LIBS%% -->
     </array>
 
 </resources>

--- a/core/asmcode_aarch64.S
+++ b/core/asmcode_aarch64.S
@@ -1,5 +1,5 @@
 .macro loadsym reg, name
-	#ifdef __clang__
+	#if defined(__clang__) && !defined(ANDROID)
 		adrp \reg, \name\()@PAGE
 		add \reg, \reg, \name\()@PAGEOFF
 	#else

--- a/core/asmcode_arm.S
+++ b/core/asmcode_arm.S
@@ -24,7 +24,7 @@ translation_sp: .global translation_sp
 #define AC_NOT_PTR 0b01
 #define AC_FLAGS (AC_INVALID|AC_NOT_PTR)
 
-#if defined(__clang__)
+#if defined(__clang__) && !defined(ANDROID)
 /* On iOS, .text relocations are permitted and due to
    a bug it's unable to handle to handle our way of
    avoiding them anyway... */

--- a/core/os/os-android.cpp
+++ b/core/os/os-android.cpp
@@ -1,0 +1,73 @@
+#include <QtAndroid>
+#include <QAndroidJniObject>
+#include <QAndroidJniEnvironment>
+#include <QAndroidActivityResultReceiver>
+
+#include "os.h"
+
+// A handler to open android content:// URLs.
+// Based on code by Florin9doi: https://github.com/nspire-emus/firebird/pull/94/files
+FILE *fopen_utf8(const char *path, const char *mode)
+{
+    const char pattern[] = "content:";
+    if(strncmp(pattern, path, sizeof(pattern)-1) != 0)
+        return fopen(path, mode);
+
+    QString android_mode; // Why did they have to NIH...
+    if(strcmp(mode, "rb") == 0)
+        android_mode = QStringLiteral("r");
+    else if(strcmp(mode, "r+b") == 0)
+        android_mode = QStringLiteral("rw");
+    else if(strcmp(mode, "wb") == 0)
+        android_mode = QStringLiteral("rwt");
+    else
+        return nullptr;
+
+    QAndroidJniObject jpath = QAndroidJniObject::fromString(QString::fromUtf8(path));
+    QAndroidJniObject jmode = QAndroidJniObject::fromString(android_mode);
+    QAndroidJniObject uri = QAndroidJniObject::callStaticObjectMethod(
+                "android/net/Uri", "parse", "(Ljava/lang/String;)Landroid/net/Uri;",
+                jpath.object<jstring>());
+
+    QAndroidJniObject contentResolver = QtAndroid::androidActivity()
+            .callObjectMethod("getContentResolver",
+                              "()Landroid/content/ContentResolver;");
+
+    // Call contentResolver.takePersistableUriPermission as we save the URI
+    int permflags = 1; // Intent.FLAG_GRANT_READ_URI_PERMISSION
+    if(android_mode.contains(QLatin1Char('w')))
+        permflags |= 2; // Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+    contentResolver.callMethod<void>("takePersistableUriPermission",
+                                     "(Landroid/net/Uri;I)V", uri.object<jobject>(), permflags);
+
+    QAndroidJniObject parcelFileDescriptor = contentResolver
+            .callObjectMethod("openFileDescriptor",
+                              "(Landroid/net/Uri;Ljava/lang/String;)Landroid/os/ParcelFileDescriptor;",
+                              uri.object<jobject>(), jmode.object<jobject>());
+
+    QAndroidJniEnvironment env;
+    if (env->ExceptionCheck())
+    {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return nullptr;
+    }
+
+    // The file descriptor needs to be duplicated as
+    QAndroidJniObject parcelFileDescriptorDup = parcelFileDescriptor
+            .callObjectMethod("dup",
+                              "()Landroid/os/ParcelFileDescriptor;");
+
+    if (env->ExceptionCheck())
+    {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return nullptr;
+    }
+
+    int fd = parcelFileDescriptorDup.callMethod<jint>("detachFd", "()I");
+    if(fd < 0)
+        return nullptr;
+
+    return fdopen(fd, mode);
+}

--- a/core/os/os-linux.c
+++ b/core/os/os-linux.c
@@ -19,7 +19,6 @@
 #include "../debug.h"
 #include "../mmu.h"
 
-
 #ifdef IS_IOS_BUILD
 
 #include <unistd.h>
@@ -44,10 +43,13 @@ int iOS_is_debugger_attached()
 }
 #endif
 
+// The implementation for android is in os-android.cpp
+#ifndef ANDROID
 FILE *fopen_utf8(const char *filename, const char *mode)
 {
     return fopen(filename, mode);
 }
+#endif
 
 void *os_reserve(size_t size)
 {
@@ -89,13 +91,15 @@ void *os_alloc_executable(size_t size)
 
 void *os_map_cow(const char *filename, size_t size)
 {
-    int fd = open(filename, O_RDONLY);
-    if(fd == -1)
+    FILE *f = fopen_utf8(filename, "rb");
+    if(!f)
         return NULL;
+
+    int fd = fileno(f);
 
     void *ret = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
 
-    close(fd);
+    fclose(f);
     return ret == MAP_FAILED ? NULL : ret;
 }
 

--- a/core/translate_aarch64.cpp
+++ b/core/translate_aarch64.cpp
@@ -836,7 +836,7 @@ void translate(uint32_t pc_start, uint32_t *insn_ptr_start)
 		mprotect(translate_buffer, INSN_BUFFER_SIZE, PROT_READ | PROT_EXEC);
 		sys_cache_control(1 /* kCacheFunctionPrepareForExecution */, jump_table_start[0], (code_end-jump_table_start[0])*4);
 	#else
-		__builtin___clear_cache(jump_table_start[0], code_end);
+		__builtin___clear_cache((char*)jump_table_start[0], (char*)code_end);
 	#endif
 }
 

--- a/core/usblink.c
+++ b/core/usblink.c
@@ -466,10 +466,17 @@ bool usblink_put_file(const char *filepath, const char *folder, usblink_progress
     current_file_callback = callback;
 
     const char *filename = filepath;
-    const char *p;
-    for (p = filepath; *p; p++)
-        if (*p == ':' || *p == '/' || *p == '\\')
-            filename = p + 1;
+    // Hack for android content:// urls
+    if(strncmp(filepath, "content://", 10) == 0) {
+        for (const char *p = filepath; *p; p++)
+            if (strncasecmp(p, "%2F", 3) == 0)
+                filename = p + 3;
+    }
+    else {
+        for (const char *p = filepath; *p; p++)
+            if (*p == ':' || *p == '/' || *p == '\\')
+                filename = p + 1;
+    }
 
     FILE *f = fopen_utf8(filepath, "rb");
     if (!f) {

--- a/firebird.pro
+++ b/firebird.pro
@@ -16,6 +16,7 @@ ios|android: SUPPORT_LINUX = false
 TRANSLATIONS += i18n/de_DE.ts i18n/fr_FR.ts
 
 QT += core gui widgets quickwidgets
+android: QT += androidextras
 CONFIG += c++11
 
 TEMPLATE = app
@@ -58,20 +59,17 @@ QMAKE_CXXFLAGS_RELEASE = -O3 -DNDEBUG
     QMAKE_CFLAGS += -Wa,--noexecstack
 }
 
-android {
-    # Fix up all relocations for known symbols, makes it faster and gets rid of some .text relocations
-    # if disabled in asmcode_arm.S.
-    QMAKE_LFLAGS += -Wl,-Bsymbolic
-}
-
 macx: ICON = resources/logo.icns
 
 # This does also apply to android
 linux|macx|ios: SOURCES += core/os/os-linux.c
 
-lessThan(QT_MINOR_VERSION, 6) {
-    # This should not be required. But somehow, it is...
-    android: DEFINES += Q_OS_ANDROID
+android {
+    # Special implementation of fopen_utf8
+    SOURCES += core/os/os-android.cpp
+    # Fix up all relocations for known symbols, makes it faster and gets rid of some .text relocations
+    # if disabled in asmcode_arm.S.
+    QMAKE_LFLAGS += -Wl,-Bsymbolic
 }
 
 ios|android: DEFINES += MOBILE_UI

--- a/firebird.pro
+++ b/firebird.pro
@@ -58,8 +58,11 @@ QMAKE_CXXFLAGS_RELEASE = -O3 -DNDEBUG
     QMAKE_CFLAGS += -Wa,--noexecstack
 }
 
-# The linker needs this somehow
-android: QMAKE_LFLAGS += -fPIC
+android {
+    # Fix up all relocations for known symbols, makes it faster and gets rid of some .text relocations
+    # if disabled in asmcode_arm.S.
+    QMAKE_LFLAGS += -Wl,-Bsymbolic
+}
 
 macx: ICON = resources/logo.icns
 

--- a/firebird.pro
+++ b/firebird.pro
@@ -113,6 +113,13 @@ linux-g++-32 {
     FB_ARCH = x86
 }
 
+android: {
+    equals(FB_ARCH, "x86") | equals(FB_ARCH, "x86_64")) {
+        # Built as shared library - forced PIC. JIT not compatible
+        TRANSLATION_ENABLED = false
+    }
+}
+
 # A platform-independant implementation of lowlevel access as default
 ASMCODE_IMPL = core/asmcode.c
 

--- a/qml/Firebird/UIComponents/FileSelect.qml
+++ b/qml/Firebird/UIComponents/FileSelect.qml
@@ -14,7 +14,8 @@ RowLayout {
         active: false
         sourceComponent: FileDialog {
             folder: Emu.dir(filePath)
-            selectExisting: root.selectExisting
+            // If save dialogs are not supported, force an open dialog
+            selectExisting: root.selectExisting || !Emu.saveDialogSupported()
             onAccepted: filePath = Emu.toLocalFile(fileUrl)
         }
     }

--- a/qmlbridge.h
+++ b/qmlbridge.h
@@ -123,6 +123,8 @@ public:
         Q_INVOKABLE void switchUIMode(bool mobile_ui);
     #endif
 
+    Q_INVOKABLE bool saveDialogSupported();
+
     void setActive(bool b);
 
 public slots:


### PR DESCRIPTION
Like #94, but uses the now native support in Qt 5.13.

Unfortunately it does not support creation of files, so only existing files can be written.

~Needs some testing, here's an APK: [firebird.zip](https://github.com/nspire-emus/firebird/files/3326263/firebird.zip)~

Depends on #184 