### PR TITLE
Fix resume if PC in SRAM and SUPPORT_LINUX disabled

### DIFF
--- a/core/debug.h
+++ b/core/debug.h
@@ -15,8 +15,6 @@ extern std::string ln_target_folder;
 extern "C" {
 #endif
 
-extern FILE *debugger_input;
-
 extern bool gdb_connected;
 extern bool in_debugger;
 extern int rdbg_port;

--- a/core/emu.cpp
+++ b/core/emu.cpp
@@ -426,9 +426,6 @@ void emu_cleanup()
 {
     exiting = true;
 
-    if(debugger_input)
-        fclose(debugger_input);
-
     // addr_cache_init is rather expensive and needs to be called once only
     //addr_cache_deinit();
 

--- a/core/mmu.c
+++ b/core/mmu.c
@@ -262,15 +262,6 @@ void *addr_cache_miss(uint32_t virt, bool writing, fault_proc *fault) {
 }
 
 void addr_cache_flush() {
-    #ifndef SUPPORT_LINUX
-        /* The OS does something incredibly stupid: For every access to the flash,
-         * it disables the MMU and flushes all buffers and caches. Argh.
-         * This causes us to drop all translations, so work around this by ignoring
-         * flushes triggered by the flash access code, which is run in SRAM. */
-         if (arm.reg[15] >> 24 == 0xa4)
-             return;
-    #endif
-
     if (arm.control & 1) {
         void *table = phys_mem_ptr(arm.translation_table_base, 0x4000);
         if (!table)


### PR DESCRIPTION
The translation table was never loaded after resume as the speed hack prevented that.

Also found an unused variable and removed it.