### PR TITLE
Various cleanups, preparations for updated android support

### DIFF
--- a/core/cpu.cpp
+++ b/core/cpu.cpp
@@ -115,11 +115,7 @@ void prefetch_abort(uint32_t mva, uint8_t status)
     cpu_exception(EX_PREFETCH_ABORT);
     if (mva == arm.reg[15])
         error("Abort occurred with exception vectors unmapped");
-    #ifndef NO_SETJMP
-        __builtin_longjmp(restart_after_exception, 1);
-    #else
-        assert(false);
-    #endif
+    return_to_loop();
 }
 
 void data_abort(uint32_t mva, uint8_t status)
@@ -130,11 +126,7 @@ void data_abort(uint32_t mva, uint8_t status)
     arm.fault_address = mva;
     arm.data_fault_status = status;
     cpu_exception(EX_DATA_ABORT);
-    #ifndef NO_SETJMP
-        __builtin_longjmp(restart_after_exception, 1);
-    #else
-        assert(false);
-    #endif
+    return_to_loop();
 }
 
 void undefined_instruction()
@@ -143,11 +135,7 @@ void undefined_instruction()
     warn("Undefined instruction at %08x\n", arm.reg[15]);
     arm.reg[15] += current_instr_size;
     cpu_exception(EX_UNDEFINED);
-    #ifndef NO_SETJMP
-        __builtin_longjmp(restart_after_exception, 1);
-    #else
-        assert(false);
-    #endif
+    return_to_loop();
 }
 
 void *try_ptr(uint32_t addr)

--- a/core/emu.cpp
+++ b/core/emu.cpp
@@ -84,15 +84,6 @@ void error(const char *fmt, ...) {
     #endif
 }
 
-int exec_hack() {
-    if (arm.reg[15] == 0x10040) {
-        arm.reg[15] = arm.reg[14];
-        warn("BOOT1 is required to run this version of BOOT2.");
-        return 1;
-    }
-    return 0;
-}
-
 extern "C" void usblink_timer();
 
 void throttle_interval_event(int index)

--- a/core/emu.cpp
+++ b/core/emu.cpp
@@ -146,7 +146,7 @@ void throttle_interval_event(int index)
         throttle_timer_wait();
 }
 
-size_t gzip_filesize(const char *path)
+static size_t gzip_filesize(const char *path)
 {
     #if __BYTE_ORDER == __LITTLE_ENDIAN
         FILE *fp = fopen_utf8(path, "rb");

--- a/core/emu.h
+++ b/core/emu.h
@@ -70,7 +70,6 @@ __attribute__((noreturn)) void error(const char *fmt, ...);
 void throttle_timer_on();
 void throttle_timer_off();
 void throttle_timer_wait();
-int exec_hack();
 void add_reset_proc(void (*proc)(void));
 
 // Is actually a jmp_buf, but __builtin_*jmp is used instead

--- a/core/emu.h
+++ b/core/emu.h
@@ -23,14 +23,10 @@ extern "C" {
 #define NO_TRANSLATION
 #endif
 
-// on iOS, setjmp and longjmp are broken
-#ifdef IS_IOS_BUILD
-#define NO_SETJMP
-#endif
-
 // Helper for micro-optimization
 #define unlikely(x) __builtin_expect(x, 0)
 #define likely(x) __builtin_expect(x, 1)
+
 static inline uint16_t BSWAP16(uint16_t x) { return x << 8 | x >> 8; }
 #define BSWAP32(x) __builtin_bswap32(x)
 
@@ -72,9 +68,8 @@ void throttle_timer_off();
 void throttle_timer_wait();
 void add_reset_proc(void (*proc)(void));
 
-// Is actually a jmp_buf, but __builtin_*jmp is used instead
-// as the MinGW variant is buggy
-extern void *restart_after_exception[32];
+// Uses emu_longjmp to return into the main loop.
+__attribute__((noreturn)) void return_to_loop(void);
 
 // GUI callbacks
 void gui_do_stuff(bool wait); // Called every once in a while...

--- a/emscripten/Makefile
+++ b/emscripten/Makefile
@@ -1,6 +1,6 @@
 CC := emcc
 CXX := em++
-FLAGS := -O3 --llvm-lto 3 -Wall -I.. -DNO_SETJMP -s USE_ZLIB=1 -s DISABLE_EXCEPTION_CATCHING=1 -s INVOKE_RUN=0 -s NO_EXIT_RUNTIME=1 -s ASSERTIONS=0 --closure 1 --pre-js firebird-utils.js
+FLAGS := -O3 --llvm-lto 3 -Wall -I.. -s USE_ZLIB=1 -s DISABLE_EXCEPTION_CATCHING=1 -s INVOKE_RUN=0 -s NO_EXIT_RUNTIME=1 -s ASSERTIONS=0 --closure 1 --pre-js firebird-utils.js
 CFLAGS := -std=c11 $(FLAGS)
 CXXFLAGS := -std=c++11 $(FLAGS)
 LFLAGS := --emrun -s TOTAL_MEMORY=500000000

--- a/emscripten/main.cpp
+++ b/emscripten/main.cpp
@@ -134,12 +134,6 @@ void emscripten_loop(bool reset)
 
     exiting = false;
 
-// clang segfaults with that, for an iOS build :(
-#ifndef NO_SETJMP
-    // Workaround for LLVM bug #18974
-    while(__builtin_setjmp(restart_after_exception)){};
-#endif
-
     emscripten_set_main_loop(step, 0, 1);
     return;
 }

--- a/emuthread.cpp
+++ b/emuthread.cpp
@@ -32,20 +32,14 @@ void gui_debug_printf(const char *fmt, ...)
 
 void gui_debug_vprintf(const char *fmt, va_list ap)
 {
-    QString str;
-    str.vsprintf(fmt, ap);
-    emu_thread.debugStr(str);
+    emu_thread.debugStr(QString::vasprintf(fmt, ap));
 }
 
 void gui_status_printf(const char *fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);
-
-    QString str;
-    str.vsprintf(fmt, ap);
-    emu_thread.statusMsg(str);
-
+    emu_thread.statusMsg(QString::vasprintf(fmt, ap));
     va_end(ap);
 }
 

--- a/firebird.pro
+++ b/firebird.pro
@@ -43,6 +43,8 @@ LIBS += -lz
 # Override bad default options to enable better optimizations
 QMAKE_CFLAGS_RELEASE = -O3 -DNDEBUG
 QMAKE_CXXFLAGS_RELEASE = -O3 -DNDEBUG
+# I don't know why g++-unix.conf sets -Wl,-O1, override that.
+!clang: QMAKE_LFLAGS_RELEASE += -Wl,-O3
 
 # Don't enable LTO with clang on Linux, incompatible with Qt (QTBUG-43556).
 !clang | !linux: {


### PR DESCRIPTION
Builds against NDK r21 and Qt 5.14.1 for armeabi-v7a and arm64-v8a now.

I was surprised that clang as provided by the NDK doesn't understand the `@PAGE` syntax needed for clang for iOS, maybe that changed in a newer llvm version?