### PR TITLE
Refactor snapshot reading/writing code

### DIFF
--- a/core/asmcode.h
+++ b/core/asmcode.h
@@ -3,6 +3,7 @@
 #ifndef _H_ASMCODE
 #define _H_ASMCODE
 
+#include "cpu.h"
 #include "emu.h"
 
 #ifdef __cplusplus

--- a/core/cpu.cpp
+++ b/core/cpu.cpp
@@ -434,14 +434,12 @@ void set_reg_bx(uint8_t i, uint32_t value)
 
 bool cpu_resume(const emu_snapshot *s)
 {
-    arm = s->cpu_state;
-    cpu_events = s->cpu_state.cpu_events_state;
-    return true;
+    return snapshot_read(s, &arm, sizeof(arm))
+           && snapshot_read(s, &cpu_events, sizeof(cpu_events));
 }
 
 bool cpu_suspend(emu_snapshot *s)
 {
-    s->cpu_state = arm;
-    s->cpu_state.cpu_events_state = cpu_events;
-    return true;
+    return snapshot_write(s, &arm, sizeof(arm))
+           && snapshot_write(s, &cpu_events, sizeof(cpu_events));
 }

--- a/core/cpu.h
+++ b/core/cpu.h
@@ -39,7 +39,6 @@ typedef struct arm_state {  // Remember to update asmcode.S if this gets rearran
     uint32_t r13_und[2], spsr_und;
 
     uint8_t  interrupts;
-    uint32_t cpu_events_state; // Only used for suspend and resume!
 }
 #ifndef __EMSCRIPTEN__
 __attribute__((packed,aligned(__alignof__(uint32_t))))

--- a/core/cx2.cpp
+++ b/core/cx2.cpp
@@ -292,18 +292,16 @@ void dma_cx2_write_word(uint32_t addr, uint32_t value)
 
 bool cx2_suspend(emu_snapshot *snapshot)
 {
-    snapshot->mem.aladdin_pmu = aladdin_pmu;
-    snapshot->mem.cx2_backlight = cx2_backlight;
-    snapshot->mem.cx2_lcd_spi = cx2_lcd_spi;
-    snapshot->mem.dma = dma;
-    return true;
+    return snapshot_write(snapshot, &aladdin_pmu, sizeof(aladdin_pmu))
+            && snapshot_write(snapshot, &cx2_backlight, sizeof(cx2_backlight))
+            && snapshot_write(snapshot, &cx2_lcd_spi, sizeof(cx2_lcd_spi))
+            && snapshot_write(snapshot, &dma, sizeof(dma));
 }
 
 bool cx2_resume(const emu_snapshot *snapshot)
 {
-    aladdin_pmu = snapshot->mem.aladdin_pmu;
-    cx2_backlight = snapshot->mem.cx2_backlight;
-    cx2_lcd_spi = snapshot->mem.cx2_lcd_spi;
-    dma = snapshot->mem.dma;
-    return true;
+    return snapshot_read(snapshot, &aladdin_pmu, sizeof(aladdin_pmu))
+            && snapshot_read(snapshot, &cx2_backlight, sizeof(cx2_backlight))
+            && snapshot_read(snapshot, &cx2_lcd_spi, sizeof(cx2_lcd_spi))
+            && snapshot_read(snapshot, &dma, sizeof(dma));
 }

--- a/core/cx2.cpp
+++ b/core/cx2.cpp
@@ -102,18 +102,6 @@ void aladdin_pmu_write(uint32_t addr, uint32_t value)
 	bad_write_word(addr, value);
 }
 
-bool aladdin_pmu_suspend(emu_snapshot *snapshot)
-{
-    snapshot->mem.aladdin_pmu = aladdin_pmu;
-    return true;
-}
-
-bool aladdin_pmu_resume(const emu_snapshot *snapshot)
-{
-    aladdin_pmu = snapshot->mem.aladdin_pmu;
-    return true;
-}
-
 /* 90120000: FTDDR3030 */
 uint32_t memc_ddr_read(uint32_t addr)
 {
@@ -174,18 +162,6 @@ void cx2_backlight_write(uint32_t addr, uint32_t value)
 		hdq1w.lcd_contrast = 255 - (cx2_backlight.pwm_value * 255) / cx2_backlight.pwm_period;
 }
 
-bool cx2_backlight_suspend(emu_snapshot *snapshot)
-{
-	snapshot->mem.cx2_backlight = cx2_backlight;
-	return true;
-}
-
-bool cx2_backlight_resume(const emu_snapshot *snapshot)
-{
-	cx2_backlight = snapshot->mem.cx2_backlight;
-	return true;
-}
-
 /* 90040000: FTSSP010 SPI controller connected to the LCD.
    Only the bare minimum to get the OS to boot is implemented. */
 struct cx2_lcd_spi_state cx2_lcd_spi;
@@ -219,18 +195,6 @@ void cx2_lcd_spi_write(uint32_t addr, uint32_t value)
 		// Ignored
 		break;
 	}
-}
-
-bool cx2_lcd_spi_suspend(emu_snapshot *snapshot)
-{
-    snapshot->mem.cx2_lcd_spi = cx2_lcd_spi;
-    return true;
-}
-
-bool cx2_lcd_spi_resume(const emu_snapshot *snapshot)
-{
-    cx2_lcd_spi = snapshot->mem.cx2_lcd_spi;
-    return true;
 }
 
 /* BC000000: An FTDMAC020 */
@@ -326,14 +290,20 @@ void dma_cx2_write_word(uint32_t addr, uint32_t value)
 	bad_write_word(addr, value);
 }
 
-bool dma_cx2_suspend(emu_snapshot *snapshot)
+bool cx2_suspend(emu_snapshot *snapshot)
 {
+    snapshot->mem.aladdin_pmu = aladdin_pmu;
+    snapshot->mem.cx2_backlight = cx2_backlight;
+    snapshot->mem.cx2_lcd_spi = cx2_lcd_spi;
     snapshot->mem.dma = dma;
     return true;
 }
 
-bool dma_cx2_resume(const emu_snapshot *snapshot)
+bool cx2_resume(const emu_snapshot *snapshot)
 {
+    aladdin_pmu = snapshot->mem.aladdin_pmu;
+    cx2_backlight = snapshot->mem.cx2_backlight;
+    cx2_lcd_spi = snapshot->mem.cx2_lcd_spi;
     dma = snapshot->mem.dma;
     return true;
 }

--- a/core/cx2.cpp
+++ b/core/cx2.cpp
@@ -1,7 +1,11 @@
 #include "emu.h"
 
+#include "mem.h"
 #include "cx2.h"
 #include "misc.h"
+#include "schedule.h"
+#include "interrupt.h"
+#include "keypad.h"
 
 /* 90140000 */
 struct aladdin_pmu_state aladdin_pmu;

--- a/core/cx2.h
+++ b/core/cx2.h
@@ -16,8 +16,6 @@ typedef struct aladdin_pmu_state {
 	uint32_t noidea[0x100 / sizeof(uint32_t)];
 } aladdin_pmu_state;
 
-bool aladdin_pmu_suspend(emu_snapshot *snapshot);
-bool aladdin_pmu_resume(const emu_snapshot *snapshot);
 void aladdin_pmu_write(uint32_t addr, uint32_t value);
 uint32_t aladdin_pmu_read(uint32_t addr);
 void aladdin_pmu_reset(void);
@@ -29,8 +27,6 @@ typedef struct cx2_backlight_state {
     uint32_t pwm_period, pwm_value;
 } cx2_backlight_state;
 
-bool cx2_backlight_suspend(emu_snapshot *snapshot);
-bool cx2_backlight_resume(const emu_snapshot *snapshot);
 void cx2_backlight_write(uint32_t addr, uint32_t value);
 void cx2_backlight_reset();
 
@@ -38,8 +34,6 @@ typedef struct cx2_lcd_spi_state {
 	bool busy;
 } cx2_lcd_spi_state;
 
-bool cx2_lcd_spi_suspend(emu_snapshot *snapshot);
-bool cx2_lcd_spi_resume(const emu_snapshot *snapshot);
 uint32_t cx2_lcd_spi_read(uint32_t addr);
 void cx2_lcd_spi_write(uint32_t addr, uint32_t value);
 
@@ -55,10 +49,13 @@ typedef struct dma_state {
 } dma_state;
 
 void dma_cx2_reset();
-bool dma_cx2_suspend(emu_snapshot *snapshot);
-bool dma_cx2_resume(const emu_snapshot *snapshot);
 uint32_t dma_cx2_read_word(uint32_t addr);
 void dma_cx2_write_word(uint32_t addr, uint32_t value);
+
+// The peripherals in cx2.cpp have trivial suspend/resume ops, so don't need
+// separate functions each.
+bool cx2_suspend(emu_snapshot *snapshot);
+bool cx2_resume(const emu_snapshot *snapshot);
 
 #ifdef __cplusplus
 }

--- a/core/des.c
+++ b/core/des.c
@@ -1,6 +1,7 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "des.h"
 #include "emu.h"
 #include "mem.h"
 

--- a/core/des.c
+++ b/core/des.c
@@ -188,12 +188,10 @@ void des_write_word(uint32_t addr, uint32_t value) {
 
 bool des_suspend(emu_snapshot *snapshot)
 {
-    snapshot->mem.des = des;
-    return true;
+    return snapshot_write(snapshot, &des, sizeof(des));
 }
 
 bool des_resume(const emu_snapshot *snapshot)
 {
-    des = snapshot->mem.des;
-    return true;
+    return snapshot_read(snapshot, &des, sizeof(des));
 }

--- a/core/des.h
+++ b/core/des.h
@@ -3,6 +3,8 @@
 #ifndef _DES_H
 #define _DES_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/core/emu.cpp
+++ b/core/emu.cpp
@@ -14,6 +14,9 @@
 #include "gdbstub.h"
 #include "usblink_queue.h"
 #include "os/os.h"
+#include "schedule.h"
+#include "misc.h"
+#include "mem.h"
 
 /* cycle_count_delta is a (usually negative) number telling what the time is relative
  * to the next scheduled event. See sched.c */

--- a/core/emu.h
+++ b/core/emu.h
@@ -92,19 +92,22 @@ typedef void (*debug_input_cb)(const char *input);
 void gui_debugger_request_input(debug_input_cb callback);
 
 #define SNAPSHOT_SIG 0xCAFEBEE0
-#define SNAPSHOT_VER 2
+#define SNAPSHOT_VER 3
 
+// Passed to resume/suspend functions.
+// Use snapshot_(read/write) to access stream contents.
 typedef struct emu_snapshot {
-    uint32_t sig; // SNAPSHOT_SIG
-    uint32_t version; // SNAPSHOT_VER
-    int product, asic_user_flags;
-    char path_boot1[512];
-    char path_flash[512];
-    sched_state sched;
-    arm_state cpu_state;
-    mem_snapshot mem;
-    flash_snapshot flash;
+    void *stream_handle;
+    struct {
+        uint32_t sig; // SNAPSHOT_SIG
+        uint32_t version; // SNAPSHOT_VER
+        char path_boot1[512];
+        char path_flash[512];
+    } header;
 } emu_snapshot;
+
+bool snapshot_read(const emu_snapshot *snapshot, void *dest, int size);
+bool snapshot_write(emu_snapshot *snapshot, const void *src, int size);
 
 bool emu_start(unsigned int port_gdb, unsigned int port_rdbg, const char *snapshot);
 void emu_loop(bool reset);

--- a/core/emu.h
+++ b/core/emu.h
@@ -5,11 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "cpu.h"
 #include "flash.h"
-#include "mem.h"
-#include "lcd.h"
-#include "schedule.h"
 
 #ifdef __cplusplus
 #include <string>

--- a/core/flash.h
+++ b/core/flash.h
@@ -3,8 +3,8 @@
 #ifndef _H_FLASH
 #define _H_FLASH
 
+#include <stddef.h>
 #include <stdint.h>
-#include <unistd.h>
 
 #ifdef __cplusplus
 #include <string>

--- a/core/flash.h
+++ b/core/flash.h
@@ -103,14 +103,8 @@ typedef struct nand_state {
 
 extern nand_state nand;
 
-typedef struct flash_snapshot {
-    nand_state state;
-    uint8_t nand_modified_blocks[]; // First modified block comes first, then the 2nd modified one etc.
-} flash_snapshot;
-
 bool flash_open(const char *filename);
 void flash_close();
-size_t flash_suspend_flexsize();
 
 struct emu_snapshot;
 bool flash_suspend(struct emu_snapshot *snapshot);

--- a/core/interrupt.c
+++ b/core/interrupt.c
@@ -225,12 +225,10 @@ void int_reset() {
 
 bool interrupt_suspend(emu_snapshot *snapshot)
 {
-    snapshot->mem.intr = intr;
-    return true;
+    return snapshot_write(snapshot, &intr, sizeof(intr));
 }
 
 bool interrupt_resume(const emu_snapshot *snapshot)
 {
-    intr = snapshot->mem.intr;
-    return true;
+    return snapshot_read(snapshot, &intr, sizeof(intr));
 }

--- a/core/keypad.cpp
+++ b/core/keypad.cpp
@@ -399,14 +399,12 @@ void touchpad_cx_write(uint32_t addr, uint32_t value) {
 
 bool keypad_suspend(emu_snapshot *snapshot)
 {
-    snapshot->mem.keypad = keypad;
-    return true;
+    return snapshot_write(snapshot, &keypad, sizeof(keypad));
 }
 
 bool keypad_resume(const emu_snapshot *snapshot)
 {
-    keypad = snapshot->mem.keypad;
-    return true;
+    return snapshot_read(snapshot, &keypad, sizeof(keypad));
 }
 
 void keypad_set_key(int row, int col, bool state)

--- a/core/lcd.c
+++ b/core/lcd.c
@@ -428,12 +428,10 @@ write_control:
 
 bool lcd_suspend(emu_snapshot *snapshot)
 {
-    snapshot->mem.lcd = lcd;
-    return true;
+    return snapshot_write(snapshot, &lcd, sizeof(lcd));
 }
 
 bool lcd_resume(const emu_snapshot *snapshot)
 {
-    lcd = snapshot->mem.lcd;
-    return true;
+    return snapshot_read(snapshot, &lcd, sizeof(lcd));
 }

--- a/core/lcd.c
+++ b/core/lcd.c
@@ -7,6 +7,7 @@
 #include "interrupt.h"
 #include "schedule.h"
 #include "mem.h"
+#include "lcd.h"
 
 static lcd_state lcd;
 

--- a/core/mem.c
+++ b/core/mem.c
@@ -518,30 +518,17 @@ bool memory_suspend(emu_snapshot *snapshot)
     snapshot->mem.sdram_size = mem_areas[1].size;
     memcpy(snapshot->mem.mem_and_flags, mem_and_flags, MEM_MAXSIZE);
 
-    return gpio_suspend(snapshot)
-            && fastboot_cx_suspend(snapshot)
-            && watchdog_suspend(snapshot)
-            && rtc_suspend(snapshot)
-            && pmu_suspend(snapshot)
+    return misc_suspend(snapshot)
             && keypad_suspend(snapshot)
-            && hdq1w_suspend(snapshot)
-            && led_suspend(snapshot)
             && usb_suspend(snapshot)
             && lcd_suspend(snapshot)
-            && adc_suspend(snapshot)
             && des_suspend(snapshot)
             && sha256_suspend(snapshot)
-            && timer_suspend(snapshot)
             && serial_suspend(snapshot)
             && interrupt_suspend(snapshot)
-            && memctl_cx_suspend(snapshot)
             && serial_cx_suspend(snapshot)
-            && timer_cx_suspend(snapshot)
-            && aladdin_pmu_suspend(snapshot)
-            && usb_cx2_suspend(snapshot)
-            && dma_cx2_suspend(snapshot)
-            && cx2_backlight_suspend(snapshot)
-            && cx2_lcd_spi_suspend(snapshot);
+            && cx2_suspend(snapshot)
+            && usb_cx2_suspend(snapshot);
 }
 
 bool memory_resume(const emu_snapshot *snapshot)
@@ -554,28 +541,15 @@ bool memory_resume(const emu_snapshot *snapshot)
     memcpy(mem_and_flags, snapshot->mem.mem_and_flags, MEM_MAXSIZE);
     memset(mem_and_flags + MEM_MAXSIZE, 0, MEM_MAXSIZE); // Set all flags to 0
 
-    return gpio_resume(snapshot)
-            && fastboot_cx_resume(snapshot)
-            && watchdog_resume(snapshot)
-            && rtc_resume(snapshot)
-            && pmu_resume(snapshot)
+    return misc_resume(snapshot)
             && keypad_resume(snapshot)
-            && hdq1w_resume(snapshot)
-            && led_resume(snapshot)
             && usb_resume(snapshot)
             && lcd_resume(snapshot)
-            && adc_resume(snapshot)
             && des_resume(snapshot)
             && sha256_resume(snapshot)
-            && timer_resume(snapshot)
             && serial_resume(snapshot)
             && interrupt_resume(snapshot)
-            && memctl_cx_resume(snapshot)
             && serial_cx_resume(snapshot)
-            && timer_cx_resume(snapshot)
-            && aladdin_pmu_resume(snapshot)
-            && usb_cx2_resume(snapshot)
-            && dma_cx2_resume(snapshot)
-            && cx2_backlight_resume(snapshot)
-            && cx2_lcd_spi_resume(snapshot);
+            && cx2_resume(snapshot)
+            && usb_cx2_resume(snapshot);
 }

--- a/core/mem.h
+++ b/core/mem.h
@@ -6,15 +6,6 @@
 #include <stdint.h>
 
 #include "cpu.h"
-#include "des.h"
-#include "misc.h"
-#include "interrupt.h"
-#include "keypad.h"
-#include "lcd.h"
-#include "sha256.h"
-#include "usb.h"
-#include "usb_cx2.h"
-#include "cx2.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/core/mem.h
+++ b/core/mem.h
@@ -72,37 +72,6 @@ void FASTCALL mmio_write_byte(uint32_t addr, uint32_t value) __asm__("mmio_write
 void FASTCALL mmio_write_half(uint32_t addr, uint32_t value) __asm__("mmio_write_half");
 void FASTCALL mmio_write_word(uint32_t addr, uint32_t value) __asm__("mmio_write_word");
 
-typedef struct mem_snapshot
-{
-    size_t sdram_size;
-    uint8_t mem_and_flags[MEM_MAXSIZE]; // TODO: No flags saved. Only RF_EXEC_BREAKPOINT and maybe RF_READ_ONLY are interesting.
-    gpio_state gpio;
-    fastboot_state fastboot;
-    watchdog_state watchdog;
-    rtc_state rtc;
-    pmu_state pmu;
-    keypad_state keypad;
-    hdq1w_state hdq1w;
-    led_state led;
-    usb_state usb;
-    lcd_state lcd;
-    adc_state adc;
-    des_state des;
-    sha256_state sha256;
-    timer_state timer;
-    timer_cx_state timer_cx;
-    serial_state serial;
-    //ti84_io_state ti84; // TODO?
-    interrupt_state intr;
-    memctl_cx_state memctl_cx;
-    serial_cx_state serial_cx;
-    aladdin_pmu_state aladdin_pmu;
-    usb_cx2_state usb_cx2;
-    dma_state dma;
-    cx2_backlight_state cx2_backlight;
-    cx2_lcd_spi_state cx2_lcd_spi;
-} mem_snapshot;
-
 bool memory_initialize(uint32_t sdram_size);
 void memory_reset();
 typedef struct emu_snapshot emu_snapshot;

--- a/core/misc.c
+++ b/core/misc.c
@@ -59,18 +59,6 @@ void nandctl_cx_write_word(uint32_t addr, uint32_t value)
     bad_write_word(addr, value);
 }
 
-bool memctl_cx_suspend(emu_snapshot *snapshot)
-{
-    snapshot->mem.memctl_cx = memctl_cx;
-    return true;
-}
-
-bool memctl_cx_resume(const emu_snapshot *snapshot)
-{
-    memctl_cx = snapshot->mem.memctl_cx;
-    return true;
-}
-
 void memctl_cx_reset(void) {
     memctl_cx.status = 0;
     memctl_cx.config = 0;
@@ -118,18 +106,6 @@ void memctl_cx_write_word(uint32_t addr, uint32_t value) {
 
 /* 90000000 */
 struct gpio_state gpio;
-
-bool gpio_resume(const emu_snapshot *snapshot)
-{
-    gpio = snapshot->mem.gpio;
-    return true;
-}
-
-bool gpio_suspend(emu_snapshot *snapshot)
-{
-    snapshot->mem.gpio = gpio;
-    return true;
-}
 
 void gpio_reset() {
     memset(&gpio, 0, sizeof gpio);
@@ -183,18 +159,6 @@ void gpio_write(uint32_t addr, uint32_t value) {
 /* 90010000, 900C0000, 900D0000 */
 static timer_state timer;
 #define ADDR_TO_TP(addr) (&timer.pairs[((addr) >> 16) % 5])
-
-bool timer_resume(const emu_snapshot *snapshot)
-{
-    timer = snapshot->mem.timer;
-    return true;
-}
-
-bool timer_suspend(emu_snapshot *snapshot)
-{
-    snapshot->mem.timer = timer;
-    return true;
-}
 
 uint32_t timer_read(uint32_t addr) {
     struct timerpair *tp = ADDR_TO_TP(addr);
@@ -289,18 +253,6 @@ void fastboot_cx_write(uint32_t addr, uint32_t value) {
     fastboot.mem[(addr & 0xFFF) >> 2] = value;
 }
 
-bool fastboot_cx_resume(const emu_snapshot *snapshot)
-{
-    fastboot = snapshot->mem.fastboot;
-    return true;
-}
-
-bool fastboot_cx_suspend(emu_snapshot *snapshot)
-{
-    snapshot->mem.fastboot = fastboot;
-    return true;
-}
-
 /* 90040000: PL022 connected to the LCI over SPI */
 uint32_t spi_cx_read(uint32_t addr) {
     switch (addr & 0xFFF)
@@ -317,18 +269,6 @@ void spi_cx_write(uint32_t addr, uint32_t value) {
 
 /* 90060000 */
 static watchdog_state watchdog;
-
-bool watchdog_resume(const emu_snapshot *snapshot)
-{
-    watchdog = snapshot->mem.watchdog;
-    return true;
-}
-
-bool watchdog_suspend(emu_snapshot *snapshot)
-{
-    snapshot->mem.watchdog = watchdog;
-    return true;
-}
 
 static void watchdog_reload() {
     if (watchdog.control & 1) {
@@ -436,18 +376,6 @@ void unknown_9008_write(uint32_t addr, uint32_t value) {
 /* 90090000 */
 struct rtc_state rtc;
 
-bool rtc_resume(const emu_snapshot *snapshot)
-{
-    rtc = snapshot->mem.rtc;
-    return true;
-}
-
-bool rtc_suspend(emu_snapshot *snapshot)
-{
-    snapshot->mem.rtc = rtc;
-    return true;
-}
-
 void rtc_reset() {
     rtc.offset = 0;
 }
@@ -539,18 +467,6 @@ void misc_write(uint32_t addr, uint32_t value) {
 /* 900B0000 */
 struct pmu_state pmu;
 
-bool pmu_resume(const emu_snapshot *snapshot)
-{
-    pmu = snapshot->mem.pmu;
-    return true;
-}
-
-bool pmu_suspend(emu_snapshot *snapshot)
-{
-    snapshot->mem.pmu = pmu;
-    return true;
-}
-
 void pmu_reset(void) {
     memset(&pmu, 0, sizeof pmu);
     // No idea what the clock speeds should actually be on reset,
@@ -622,17 +538,6 @@ void pmu_write(uint32_t addr, uint32_t value) {
 /* 90010000, 900C0000(?), 900D0000 */
 static timer_cx_state timer_cx;
 static void timer_cx_event(int index);
-bool timer_cx_resume(const emu_snapshot *snapshot)
-{
-    timer_cx = snapshot->mem.timer_cx;
-    return true;
-}
-
-bool timer_cx_suspend(emu_snapshot *snapshot)
-{
-    snapshot->mem.timer_cx = timer_cx;
-    return true;
-}
 
 void timer_cx_int_check(int which) {
     int_set(INT_TIMER0+which, (timer_cx.timer[which][0].interrupt & timer_cx.timer[which][0].control >> 5)
@@ -736,18 +641,6 @@ void timer_cx_reset() {
 /* 900F0000 */
 hdq1w_state hdq1w;
 
-bool hdq1w_resume(const emu_snapshot *snapshot)
-{
-    hdq1w = snapshot->mem.hdq1w;
-    return true;
-}
-
-bool hdq1w_suspend(emu_snapshot *snapshot)
-{
-    snapshot->mem.hdq1w = hdq1w;
-    return true;
-}
-
 void hdq1w_reset() {
     hdq1w.lcd_contrast = 0;
 }
@@ -773,16 +666,6 @@ void hdq1w_write(uint32_t addr, uint32_t value) {
 
 /* 90110000: LED */
 static led_state led;
-
-bool led_resume(const emu_snapshot *snapshot) {
-    led = snapshot->mem.led;
-    return true;
-}
-
-bool led_suspend(emu_snapshot *snapshot) {
-    snapshot->mem.led = led;
-    return true;
-}
 
 void led_reset() {
     memset(&led, 0, sizeof(led));
@@ -914,18 +797,6 @@ void sramctl_write_word(uint32_t addr, uint32_t value) {
 /* C4000000: ADC (Analog-to-Digital Converter) */
 static adc_state adc;
 
-bool adc_resume(const emu_snapshot *snapshot)
-{
-    adc = snapshot->mem.adc;
-    return true;
-}
-
-bool adc_suspend(emu_snapshot *snapshot)
-{
-    snapshot->mem.adc = adc;
-    return true;
-}
-
 static uint16_t adc_read_channel(int n) {
     if (pmu.disable2 & 0x10)
         return 0x3FF;
@@ -1015,4 +886,36 @@ void adc_cx2_write_word(uint32_t addr, uint32_t value)
     (void) value;
     // It expects an IRQ on writing something
     int_set(INT_ADC, 1);
+}
+
+bool misc_suspend(emu_snapshot *snapshot)
+{
+    snapshot->mem.memctl_cx = memctl_cx;
+    snapshot->mem.gpio = gpio;
+    snapshot->mem.timer = timer;
+    snapshot->mem.fastboot = fastboot;
+    snapshot->mem.watchdog = watchdog;
+    snapshot->mem.rtc = rtc;
+    snapshot->mem.pmu = pmu;
+    snapshot->mem.timer_cx = timer_cx;
+    snapshot->mem.hdq1w = hdq1w;
+    snapshot->mem.led = led;
+    snapshot->mem.adc = adc;
+    return true;
+}
+
+bool misc_resume(const emu_snapshot *snapshot)
+{
+    memctl_cx = snapshot->mem.memctl_cx;
+    gpio = snapshot->mem.gpio;
+    timer = snapshot->mem.timer;
+    fastboot = snapshot->mem.fastboot;
+    watchdog = snapshot->mem.watchdog;
+    rtc = snapshot->mem.rtc;
+    pmu = snapshot->mem.pmu;
+    timer_cx = snapshot->mem.timer_cx;
+    hdq1w = snapshot->mem.hdq1w;
+    led = snapshot->mem.led;
+    adc = snapshot->mem.adc;
+    return true;
 }

--- a/core/misc.c
+++ b/core/misc.c
@@ -890,32 +890,30 @@ void adc_cx2_write_word(uint32_t addr, uint32_t value)
 
 bool misc_suspend(emu_snapshot *snapshot)
 {
-    snapshot->mem.memctl_cx = memctl_cx;
-    snapshot->mem.gpio = gpio;
-    snapshot->mem.timer = timer;
-    snapshot->mem.fastboot = fastboot;
-    snapshot->mem.watchdog = watchdog;
-    snapshot->mem.rtc = rtc;
-    snapshot->mem.pmu = pmu;
-    snapshot->mem.timer_cx = timer_cx;
-    snapshot->mem.hdq1w = hdq1w;
-    snapshot->mem.led = led;
-    snapshot->mem.adc = adc;
-    return true;
+    return snapshot_write(snapshot, &memctl_cx, sizeof(memctl_cx))
+            && snapshot_write(snapshot, &gpio, sizeof(gpio))
+            && snapshot_write(snapshot, &timer, sizeof(timer))
+            && snapshot_write(snapshot, &fastboot, sizeof(fastboot))
+            && snapshot_write(snapshot, &watchdog, sizeof(watchdog))
+            && snapshot_write(snapshot, &rtc, sizeof(rtc))
+            && snapshot_write(snapshot, &pmu, sizeof(pmu))
+            && snapshot_write(snapshot, &timer_cx, sizeof(timer_cx))
+            && snapshot_write(snapshot, &hdq1w, sizeof(hdq1w))
+            && snapshot_write(snapshot, &led, sizeof(led))
+            && snapshot_write(snapshot, &adc, sizeof(adc));
 }
 
 bool misc_resume(const emu_snapshot *snapshot)
 {
-    memctl_cx = snapshot->mem.memctl_cx;
-    gpio = snapshot->mem.gpio;
-    timer = snapshot->mem.timer;
-    fastboot = snapshot->mem.fastboot;
-    watchdog = snapshot->mem.watchdog;
-    rtc = snapshot->mem.rtc;
-    pmu = snapshot->mem.pmu;
-    timer_cx = snapshot->mem.timer_cx;
-    hdq1w = snapshot->mem.hdq1w;
-    led = snapshot->mem.led;
-    adc = snapshot->mem.adc;
-    return true;
+    return snapshot_read(snapshot, &memctl_cx, sizeof(memctl_cx))
+            && snapshot_read(snapshot, &gpio, sizeof(gpio))
+            && snapshot_read(snapshot, &timer, sizeof(timer))
+            && snapshot_read(snapshot, &fastboot, sizeof(fastboot))
+            && snapshot_read(snapshot, &watchdog, sizeof(watchdog))
+            && snapshot_read(snapshot, &rtc, sizeof(rtc))
+            && snapshot_read(snapshot, &pmu, sizeof(pmu))
+            && snapshot_read(snapshot, &timer_cx, sizeof(timer_cx))
+            && snapshot_read(snapshot, &hdq1w, sizeof(hdq1w))
+            && snapshot_read(snapshot, &led, sizeof(led))
+            && snapshot_read(snapshot, &adc, sizeof(adc));
 }

--- a/core/misc.h
+++ b/core/misc.h
@@ -22,8 +22,6 @@ typedef struct memctl_cx_state {
     uint32_t nandctl_ecc_memcfg;
 } memctl_cx_state;
 
-bool memctl_cx_suspend(emu_snapshot *snapshot);
-bool memctl_cx_resume(const emu_snapshot *snapshot);
 void memctl_cx_reset(void);
 uint32_t memctl_cx_read_word(uint32_t addr);
 void memctl_cx_write_word(uint32_t addr, uint32_t value);
@@ -39,8 +37,6 @@ typedef struct gpio_state {
 } gpio_state;
 extern gpio_state gpio;
 
-bool gpio_suspend(emu_snapshot *snapshot);
-bool gpio_resume(const emu_snapshot *snapshot);
 void gpio_reset();
 uint32_t gpio_read(uint32_t addr);
 void gpio_write(uint32_t addr, uint32_t value);
@@ -64,8 +60,6 @@ typedef struct timer_state {
     struct timerpair pairs[3];
 } timer_state;
 
-bool timer_suspend(emu_snapshot *snapshot);
-bool timer_resume(const emu_snapshot *snapshot);
 uint32_t timer_read(uint32_t addr);
 void timer_write(uint32_t addr, uint32_t value);
 void timer_reset(void);
@@ -106,8 +100,6 @@ typedef struct fastboot_state {
     uint32_t mem[0x1000 / sizeof(uint32_t)];
 } fastboot_state;
 
-bool fastboot_cx_suspend(emu_snapshot *snapshot);
-bool fastboot_cx_resume(const emu_snapshot *snapshot);
 uint32_t fastboot_cx_read(uint32_t addr);
 void fastboot_cx_write(uint32_t addr, uint32_t value);
 
@@ -122,8 +114,6 @@ typedef struct watchdog_state {
     uint8_t locked;
 } watchdog_state;
 
-bool watchdog_suspend(emu_snapshot *snapshot);
-bool watchdog_resume(const emu_snapshot *snapshot);
 void watchdog_reset();
 uint32_t watchdog_read(uint32_t addr);
 void watchdog_write(uint32_t addr, uint32_t value);
@@ -135,8 +125,6 @@ typedef struct rtc_state {
     time_t offset;
 } rtc_state;
 
-bool rtc_suspend(emu_snapshot *snapshot);
-bool rtc_resume(const emu_snapshot *snapshot);
 void rtc_reset();
 uint32_t rtc_read(uint32_t addr);
 void rtc_write(uint32_t addr, uint32_t value);
@@ -154,8 +142,6 @@ typedef struct pmu_state {
 } pmu_state;
 extern pmu_state pmu;
 
-bool pmu_suspend(emu_snapshot *snapshot);
-bool pmu_resume(const emu_snapshot *snapshot);
 void pmu_reset(void);
 uint32_t pmu_read(uint32_t addr);
 void pmu_write(uint32_t addr, uint32_t value);
@@ -173,8 +159,6 @@ typedef struct timer_cx_state {
     struct cx_timer timer[3][2];
 } timer_cx_state;
 
-bool timer_cx_suspend(emu_snapshot *snapshot);
-bool timer_cx_resume(const emu_snapshot *snapshot);
 uint32_t timer_cx_read(uint32_t addr);
 void timer_cx_write(uint32_t addr, uint32_t value);
 void timer_cx_reset(void);
@@ -184,8 +168,6 @@ typedef struct hdq1w_state {
 } hdq1w_state;
 extern hdq1w_state hdq1w;
 
-bool hdq1w_suspend(emu_snapshot *snapshot);
-bool hdq1w_resume(const emu_snapshot *snapshot);
 void hdq1w_reset(void);
 uint32_t hdq1w_read(uint32_t addr);
 void hdq1w_write(uint32_t addr, uint32_t value);
@@ -194,8 +176,6 @@ typedef struct led_state {
     uint32_t regs[5];
 } led_state;
 
-bool led_suspend(emu_snapshot *snapshot);
-bool led_resume(const emu_snapshot *snapshot);
 void led_reset(void);
 uint32_t led_read_word(uint32_t addr);
 void led_write_word(uint32_t addr, uint32_t value);
@@ -227,8 +207,6 @@ typedef struct adc_state {
     struct adc_channel channel[7];
 } adc_state;
 
-bool adc_suspend(emu_snapshot *snapshot);
-bool adc_resume(const emu_snapshot *snapshot);
 void adc_reset();
 uint32_t adc_read_word(uint32_t addr);
 void adc_write_word(uint32_t addr, uint32_t value);
@@ -236,6 +214,11 @@ void adc_write_word(uint32_t addr, uint32_t value);
 // CX2: 0x900B0000
 uint32_t adc_cx2_read_word(uint32_t addr);
 void adc_cx2_write_word(uint32_t addr, uint32_t value);
+
+// The peripherals in misc.c have trivial suspend/resume ops, so don't need
+// separate functions each. Note: serial/serial_cx is in serial.c instead.
+bool misc_suspend(emu_snapshot *snapshot);
+bool misc_resume(const emu_snapshot *snapshot);
 
 #ifdef __cplusplus
 }

--- a/core/serial.c
+++ b/core/serial.c
@@ -70,14 +70,12 @@ static serial_state serial;
 
 bool serial_resume(const emu_snapshot *snapshot)
 {
-    serial = snapshot->mem.serial;
-    return true;
+    return snapshot_read(snapshot, &serial, sizeof(serial));
 }
 
 bool serial_suspend(emu_snapshot *snapshot)
 {
-    snapshot->mem.serial = serial;
-    return true;
+    return snapshot_write(snapshot, &serial, sizeof(serial));
 }
 
 static void serial_int_check() {
@@ -160,14 +158,12 @@ static serial_cx_state serial_cx;
 
 bool serial_cx_resume(const emu_snapshot *snapshot)
 {
-    serial_cx = snapshot->mem.serial_cx;
-    return true;
+    return snapshot_read(snapshot, &serial_cx, sizeof(serial_cx));
 }
 
 bool serial_cx_suspend(emu_snapshot *snapshot)
 {
-    snapshot->mem.serial_cx = serial_cx;
-    return true;
+    return snapshot_write(snapshot, &serial_cx, sizeof(serial_cx));
 }
 
 static inline void serial_cx_int_check() {

--- a/core/sha256.c
+++ b/core/sha256.c
@@ -115,12 +115,10 @@ void sha256_write_word(uint32_t addr, uint32_t value) {
 
 bool sha256_suspend(emu_snapshot *snapshot)
 {
-    snapshot->mem.sha256 = sha256;
-    return true;
+    return snapshot_write(snapshot, &sha256, sizeof(sha256));
 }
 
 bool sha256_resume(const emu_snapshot *snapshot)
 {
-    sha256 = snapshot->mem.sha256;
-    return true;
+    return snapshot_read(snapshot, &sha256, sizeof(sha256));
 }

--- a/core/sha256.c
+++ b/core/sha256.c
@@ -1,5 +1,6 @@
 #include <string.h>
 #include "emu.h"
+#include "sha256.h"
 #include "mem.h"
 
 static sha256_state sha256;

--- a/core/usb.c
+++ b/core/usb.c
@@ -261,12 +261,10 @@ void usb_write_word(uint32_t addr, uint32_t value) {
 
 bool usb_suspend(emu_snapshot *snapshot)
 {
-    snapshot->mem.usb = usb;
-    return true;
+    return snapshot_write(snapshot, &usb, sizeof(usb));
 }
 
 bool usb_resume(const emu_snapshot *snapshot)
 {
-    usb = snapshot->mem.usb;
-    return true;
+    return snapshot_read(snapshot, &usb, sizeof(usb));
 }

--- a/core/usb_cx2.cpp
+++ b/core/usb_cx2.cpp
@@ -3,8 +3,10 @@
 
 #include "emu.h"
 #include "mem.h"
+#include "usb.h"
 #include "usb_cx2.h"
 #include "usblink_cx2.h"
+#include "interrupt.h"
 
 usb_cx2_state usb_cx2;
 

--- a/core/usb_cx2.cpp
+++ b/core/usb_cx2.cpp
@@ -106,9 +106,8 @@ static void usb_cx2_packet_from_calc(uint8_t ep, uint8_t *packet, size_t size)
 void usb_cx2_reset()
 {
     usb_cx2 = {};
-    usb.usbcmd = 0x80000;
-    usb.portsc = 0xEC000004;
     usb_cx2.usbcmd = 0x80000;
+    usb_cx2.portsc = 0xEC000004;
     // All IRQs masked
     usb_cx2.imr = 0xF;
     usb_cx2.otgier = 0;

--- a/core/usb_cx2.cpp
+++ b/core/usb_cx2.cpp
@@ -542,12 +542,10 @@ uint16_t usb_cx2_read_half(uint32_t addr)
 
 bool usb_cx2_suspend(emu_snapshot *snapshot)
 {
-    snapshot->mem.usb_cx2 = usb_cx2;
-    return true;
+    return snapshot_write(snapshot, &usb_cx2, sizeof(usb_cx2));
 }
 
 bool usb_cx2_resume(const emu_snapshot *snapshot)
 {
-    usb_cx2 = snapshot->mem.usb_cx2;
-    return true;
+    return snapshot_read(snapshot, &usb_cx2, sizeof(usb_cx2));
 }

--- a/core/usblink.c
+++ b/core/usblink.c
@@ -7,6 +7,7 @@
 
 #include "emu.h"
 #include "usb.h"
+#include "usb_cx2.h"
 #include "usblink.h"
 #include "usblink_cx2.h"
 #include "os/os.h"

--- a/core/usblink_cx2.cpp
+++ b/core/usblink_cx2.cpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>

--- a/kitmodel.cpp
+++ b/kitmodel.cpp
@@ -1,3 +1,6 @@
+#include <QDataStream>
+#include <QDebug>
+
 #include "core/flash.h"
 #include "core/os/os.h"
 

--- a/kitmodel.h
+++ b/kitmodel.h
@@ -1,7 +1,7 @@
 #ifndef KITMODEL_H
 #define KITMODEL_H
 
-#include <QtQml>
+#include <QAbstractListModel>
 
 struct Kit
 {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1,5 +1,3 @@
-#include <future>
-
 #include <QFileDialog>
 #include <QStandardPaths>
 #include <QTextBlock>

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -1,8 +1,6 @@
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H
 
-#include <atomic>
-
 #include <QMainWindow>
 #include <QSettings>
 #include <QLabel>

--- a/qmlbridge.cpp
+++ b/qmlbridge.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <cassert>
 #include <unistd.h>
 

--- a/qmlbridge.h
+++ b/qmlbridge.h
@@ -4,7 +4,6 @@
 #include <QObject>
 #include <QtQml>
 
-#include "emuthread.h"
 #include "kitmodel.h"
 
 class QMLBridge : public QObject


### PR DESCRIPTION
Reading from/writing to the snapshot explicitly instead of manipulating a full
copy in RAM has various advantages:
- Data goes directly from the source to the destination, without having a full
  uncompressed copy in between
- Avoid memory use of the full copy
- No need for a struct which includes all peripheral state
- Content is more flexible, as opposed to allowing flexible data only at the
  end

Includes some cleanup before and after.

I also thought about going into a different direction. By having `emu_snapshot` as the "live" copy of the peripheral state, it would also avoid the full copy. I decided against that because it means that practically every file has to include all peripheral headers to calculate struct offsets and it would need changes all over the place due to the added indirection.