### PR TITLE
Alternative ALT behaviour

### DIFF
--- a/qtkeypadbridge.cpp
+++ b/qtkeypadbridge.cpp
@@ -71,17 +71,16 @@ void keyToKeypad(QKeyEvent *event)
         ,{Qt::Key_Y, keymap::ay}
         ,{Qt::Key_Z, keymap::az}
         ,{Qt::Key_Less, keymap::ee}
-        ,{Qt::Key_Less | ALT, keymap::ee}
+        ,{Qt::Key_Comma | ALT, keymap::ee} //US keyboard '<' is [Shift]+[,]
         ,{Qt::Key_E | ALT, keymap::ee}
         ,{Qt::Key_Bar, keymap::pi}
-        ,{Qt::Key_Bar | ALT, keymap::pi}
+        ,{Qt::Key_Backslash | ALT, keymap::pi} //US keyboard '|' is [Shift]+[\]
         ,{Qt::Key_Comma, keymap::comma}
-        ,{Qt::Key_Comma | ALT, keymap::comma}
         ,{Qt::Key_Question, keymap::punct}
-        ,{Qt::Key_Question | ALT, keymap::punct}
+        ,{Qt::Key_Slash | ALT, keymap::punct} //US keyboard '?' is [Shift]+[/]
         ,{Qt::Key_W | ALT, keymap::punct}
         ,{Qt::Key_Greater, keymap::flag}
-        ,{Qt::Key_Greater | ALT, keymap::flag}
+        ,{Qt::Key_Period | ALT, keymap::flag} //US keyboard '>' is [Shift]+[.]
         ,{Qt::Key_F | ALT, keymap::flag}
         ,{Qt::Key_Space, keymap::space}
         ,{Qt::Key_Enter | ALT, keymap::ret}
@@ -99,57 +98,43 @@ void keyToKeypad(QKeyEvent *event)
         ,{Qt::Key_8, keymap::n8}
         ,{Qt::Key_9, keymap::n9}
         ,{Qt::Key_Period, keymap::dot}
-        ,{Qt::Key_Period | ALT, keymap::dot}
         ,{Qt::Key_Minus | ALT, keymap::neg}
         ,{Qt::Key_QuoteLeft, keymap::neg}
-        ,{Qt::Key_QuoteLeft | ALT, keymap::neg}
 
             // Left buttons
         ,{Qt::Key_Equal, keymap::equ}
-        ,{Qt::Key_Equal | ALT, keymap::equ}
         ,{Qt::Key_Q | ALT, keymap::equ}
         ,{Qt::Key_Backslash, keymap::trig}
-        ,{Qt::Key_Backslash | ALT, keymap::trig}
         ,{Qt::Key_T | ALT, keymap::trig}
         ,{Qt::Key_AsciiCircum, keymap::pow}
-        ,{Qt::Key_AsciiCircum | ALT, keymap::pow}
+        ,{Qt::Key_6 | ALT, keymap::pow} //US keyboard '^' is [Shift]+[6]
         ,{Qt::Key_P | ALT, keymap::pow}
         ,{Qt::Key_At, keymap::squ}
-        ,{Qt::Key_At | ALT, keymap::squ}
-        ,{Qt::Key_2 | ALT, keymap::squ}
+        ,{Qt::Key_2 | ALT, keymap::squ} //US keyboard '@' is [Shift]+[2]
         ,{Qt::Key_BracketLeft, keymap::exp}
-        ,{Qt::Key_BracketLeft | ALT, keymap::exp}
         ,{Qt::Key_X | ALT, keymap::exp}
         ,{Qt::Key_BracketRight, keymap::pow10}
-        ,{Qt::Key_BracketRight | ALT, keymap::pow10}
         ,{Qt::Key_1 | ALT, keymap::pow10}
         ,{Qt::Key_ParenLeft, keymap::pleft}
-        ,{Qt::Key_ParenLeft | ALT, keymap::pleft}
+        ,{Qt::Key_9 | ALT, keymap::pleft} //US keyboard '(' is [Shift]+[9]
         ,{Qt::Key_F1, keymap::pleft}
         ,{Qt::Key_ParenRight, keymap::pright}
-        ,{Qt::Key_ParenRight | ALT, keymap::pright}
+        ,{Qt::Key_0 | ALT, keymap::pright} //US keyboard ')' is [Shift]+[0]
         ,{Qt::Key_F2, keymap::pright}
 
             // Right buttons
         ,{Qt::Key_Semicolon, keymap::metrix}
-        ,{Qt::Key_Semicolon | ALT, keymap::metrix}
         ,{Qt::Key_O | ALT, keymap::metrix}
         ,{Qt::Key_Apostrophe, keymap::cat}
-        ,{Qt::Key_Apostrophe | ALT, keymap::cat}
         ,{Qt::Key_C | ALT, keymap::cat}
         ,{Qt::Key_Asterisk, keymap::mult}
-        ,{Qt::Key_Asterisk | ALT, keymap::mult}
         ,{Qt::Key_A | ALT, keymap::mult}
         ,{Qt::Key_Slash, keymap::div}
-        ,{Qt::Key_Slash | ALT, keymap::div}
         ,{Qt::Key_F3, keymap::div}
         ,{Qt::Key_Plus, keymap::plus}
-        ,{Qt::Key_Plus | ALT, keymap::plus}
-        ,{Qt::Key_Equal | ALT, keymap::plus}
+        ,{Qt::Key_Equal | ALT, keymap::plus} //US keyboard '+' is [Shift]+[=]
         ,{Qt::Key_Minus, keymap::minus}
-        ,{Qt::Key_Minus | ALT, keymap::minus}
         ,{Qt::Key_Underscore, keymap::minus}
-        ,{Qt::Key_Underscore | ALT, keymap::minus}
         ,{Qt::Key_Enter, keymap::enter}
         ,{Qt::Key_Return, keymap::enter}
     };


### PR DESCRIPTION
Makes the following changes to the keymap:

1.
Remove all instances where [ALT]+['key'] and ['key'] both map to the same calculator key, freeing up those key combinations for something more useful.

Reasoning: No one is going to press [Alt]+['key'] when it does the same thing as just ['key'], so it is a waste to have it as such, and there are better things that can be done with those key combinations.

This also fixes the following conflict by removing line 150, making [Alt]+[-] map only to '(-)' (negation):
line 103:        ,{Qt::Key_Minus | ALT, keymap::neg}
line 150:        ,{Qt::Key_Minus | ALT, keymap::minus}

2.
Add instances where mappings using symbols made (on US keyboards) by typing [Shift]+['key'] are also mapped to [Alt]+['key'], in the same way as [Alt]+[2] and [@] are both assigned to the 'x^2' calculator key, and [Alt]+[=] and [+] are both assigned to the '+' calculator key, already.

Reasoning:
Since [Shift] = 'shift' on calculator, it would (arguably) be better to not have to use [Shift] outside of the calculator's usage as it can cause unintended problems.