### PR TITLE
Fix PTT for CX and CX II

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,11 @@
 * Better debugger integration
 * Don't use a 60Hz timer for LCD redrawing, hook lcd_event instead
 * Less global vars (emu.h), move into structs
-* Use streams for reading/writing snapshots instead of struct emu_snapshot 
+* Use streams for reading/writing snapshots instead of struct emu_snapshot
+* Fastboot data is currently not cleared at all, it survives soft and hard
+  resets as well as restarts. This was the simplest way to get installers to
+  work, which require that state is persisted across software resets. Ideally,
+  fastboot data is cleared on hardware resets and restarts.
 
 ##Wishlist:
 * Skin loader/switcher

--- a/core/cpu.cpp
+++ b/core/cpu.cpp
@@ -432,6 +432,17 @@ void set_reg_bx(uint8_t i, uint32_t value)
     }
 }
 
+void cpu_reset()
+{
+    memset(&arm, 0, sizeof arm);
+    arm.control = 0x00050078;
+    arm.cpsr_low28 = MODE_SVC | 0xC0;
+    cpu_events &= EVENT_DEBUG_STEP;
+
+    addr_cache_flush();
+    flush_translations();
+}
+
 bool cpu_resume(const emu_snapshot *s)
 {
     return snapshot_read(s, &arm, sizeof(arm))

--- a/core/cpu.h
+++ b/core/cpu.h
@@ -84,6 +84,7 @@ extern struct arm_state arm __asm__("arm");
 #endif
 
 typedef struct emu_snapshot emu_snapshot;
+void cpu_reset(); // Essentially a soft reset
 bool cpu_resume(const emu_snapshot *s);
 bool cpu_suspend(emu_snapshot *s);
 void cpu_int_check();

--- a/core/cx2.cpp
+++ b/core/cx2.cpp
@@ -77,7 +77,7 @@ void aladdin_pmu_write(uint32_t addr, uint32_t value)
 			if(value & 2)
 			{
 				/* enter sleep, jump to 0 when On pressed. */
-				warn("Sleep not implemented");
+				cpu_events |= EVENT_SLEEP;
 				// Without this, the clocks are wrong
 				aladdin_pmu_reset();
 			}

--- a/core/emu.cpp
+++ b/core/emu.cpp
@@ -348,6 +348,12 @@ void emu_loop(bool reset)
                 goto reset;
             }
 
+            if (cpu_events & EVENT_SLEEP) {
+                assert(emulate_cx2);
+                cycle_count_delta = 0;
+                break;
+            }
+
             if (cpu_events & (EVENT_FIQ | EVENT_IRQ)) {
                 // Align PC in case the interrupt occurred immediately after a jump
                 if (arm.cpsr_low28 & 0x20)

--- a/core/emu.h
+++ b/core/emu.h
@@ -33,6 +33,7 @@ extern uint32_t cpu_events __asm__("cpu_events");
 #define EVENT_RESET 4
 #define EVENT_DEBUG_STEP 8
 #define EVENT_WAITING 16
+#define EVENT_SLEEP 32
 
 // Settings
 extern bool exiting, debug_on_start, debug_on_warn, print_on_warn;

--- a/core/keypad.cpp
+++ b/core/keypad.cpp
@@ -30,8 +30,8 @@ void keypad_int_check() {
 }
 
 void keypad_on_pressed() {
-    // TODO: The CX II probably has the enable bit elsewhere
-    if(emulate_cx2 || (!emulate_cx2 && pmu.on_irq_enabled))
+    // TODO: The CX II may have an enable bit somewhere
+    if(!emulate_cx2 && pmu.on_irq_enabled)
         int_set(INT_POWER, true);
 }
 
@@ -91,6 +91,13 @@ static void keypad_scan_event(int index) {
     uint16_t row = ~keypad.key_map[keypad.kpc.current_row];
     row &= ~(0x80000 >> keypad.kpc.current_row); // Emulate weird diagonal glitch
     row |= ~0u << (keypad.kpc.size >> 8 & 0xFF);  // Unused columns read as 1
+
+    // Touchpad and CX keypads don't actually handle the On key,
+    // that's done by the PMU. Its state is tracked in key_map though,
+    // so mask it out.
+    if(keypad.kpc.current_row == 0)
+        row |= (1 << 9);
+
     if (emulate_cx)
         row = ~row;
 

--- a/core/keypad.cpp
+++ b/core/keypad.cpp
@@ -33,6 +33,11 @@ void keypad_on_pressed() {
     // TODO: The CX II may have an enable bit somewhere
     if(!emulate_cx2 && pmu.on_irq_enabled)
         int_set(INT_POWER, true);
+
+    if(cpu_events & EVENT_SLEEP) {
+        assert(emulate_cx2);
+        cpu_reset();
+    }
 }
 
 uint32_t keypad_read(uint32_t addr) {

--- a/core/misc.c
+++ b/core/misc.c
@@ -245,9 +245,15 @@ void timer_reset() {
 static fastboot_state fastboot;
 
 uint32_t fastboot_cx_read(uint32_t addr) {
+    if((addr & 0xFFFF) >= 0x1000)
+        return bad_read_word(addr); // On HW it repeats
+
     return fastboot.mem[(addr & 0xFFF) >> 2];
 }
 void fastboot_cx_write(uint32_t addr, uint32_t value) {
+    if((addr & 0xFFFF) >= 0x1000)
+        return bad_write_word(addr, value);
+
     // TODO: This isn't cleared on resets, but should be cleared
     // eventually, probably on restarts?
     fastboot.mem[(addr & 0xFFF) >> 2] = value;


### PR DESCRIPTION
The On button has different behaviour. On the CX II, sleep mode had to be implemented to even allow turning it off and on.