### PR TITLE
Keypad improvements

### DIFF
--- a/qml/Keypad.qml
+++ b/qml/Keypad.qml
@@ -19,6 +19,10 @@ Rectangle {
         anchors.leftMargin: 5
         anchors.top: rectangle3.top
         anchors.topMargin: 0
+        // This defaults to 5 and is affected by scaling,
+        // which is not desired here as the keypad is scaled
+        // by its parent already.
+        spacing: 0
 
         NBigButton {
             id: nButton1
@@ -69,6 +73,9 @@ Rectangle {
         anchors.topMargin: 0
         anchors.right: parent.right
         anchors.rightMargin: 5
+        // See above.
+        spacing: 0
+
         NBigButton {
             id: nButton4
             text: "⌂on"

--- a/qml/Keypad.qml
+++ b/qml/Keypad.qml
@@ -48,7 +48,7 @@ Rectangle {
                 horizontalAlignment: Text.AlignHCenter
                 font.pixelSize: 9
                 anchors.bottomMargin: 0
-                font.bold: false
+                font.bold: true
                 verticalAlignment: Text.AlignVCenter
                 anchors.bottom: parent.top
             }
@@ -112,7 +112,7 @@ Rectangle {
                 horizontalAlignment: Text.AlignHCenter
                 font.pixelSize: 9
                 anchors.bottomMargin: 0
-                font.bold: false
+                font.bold: true
                 verticalAlignment: Text.AlignVCenter
                 anchors.bottom: parent.top
             }
@@ -120,17 +120,15 @@ Rectangle {
 
         NBigButton {
             id: nButton6
-            width: 30
             text: "menu"
             Layout.fillWidth: true
             keymap_id: 71
 
             Image {
                 source: "qrc:/keyimages/resources/keyimages/context_menu.png"
-                width: nButton6.width * .5
+                height: 10
                 anchors.bottom: nButton6.top
-                anchors.left: nButton6.left
-                anchors.leftMargin: nButton6.width / 4
+                anchors.horizontalCenter: parent.horizontalCenter
                 fillMode: Image.PreserveAspectFit
                 smooth: true
                 mipmap: true
@@ -164,7 +162,7 @@ Rectangle {
         anchors.bottom: nButton8.bottom
         anchors.bottomMargin: 0
         anchors.top: rectangle3.bottom
-        anchors.topMargin: 10
+        anchors.topMargin: 12
 
         NBigButton {
             id: nButton11
@@ -182,18 +180,11 @@ Rectangle {
                 text: "CAPS"
                 anchors.bottom: parent.top
                 horizontalAlignment: Text.AlignHCenter
-                font.pixelSize: 10
+                font.pixelSize: 9
                 anchors.bottomMargin: 0
-                font.bold: false
+                font.bold: true
                 verticalAlignment: Text.AlignVCenter
             }
-        }
-
-        Rectangle {
-            id: rectangle2
-            width: 30
-            height: 20
-            color: "#00000000"
         }
 
         NBigButton {
@@ -205,6 +196,7 @@ Rectangle {
             border.width: 1
             clip: false
             keymap_id: 56
+            Layout.column: 2
 
             Text {
                 id: text4
@@ -216,9 +208,9 @@ Rectangle {
                 text: "sto→"
                 anchors.bottom: parent.top
                 horizontalAlignment: Text.AlignHCenter
-                font.pixelSize: 10
+                font.pixelSize: 9
                 anchors.bottomMargin: 0
-                font.bold: false
+                font.bold: true
                 verticalAlignment: Text.AlignVCenter
             }
         }
@@ -301,7 +293,7 @@ Rectangle {
                 horizontalAlignment: Text.AlignHCenter
                 font.pixelSize: 9
                 anchors.bottomMargin: 0
-                font.bold: false
+                font.bold: true
                 verticalAlignment: Text.AlignVCenter
             }
         }
@@ -323,7 +315,7 @@ Rectangle {
                 horizontalAlignment: Text.AlignHCenter
                 font.pixelSize: 9
                 anchors.bottomMargin: 0
-                font.bold: false
+                font.bold: true
                 verticalAlignment: Text.AlignVCenter
             }
         }
@@ -365,9 +357,9 @@ Rectangle {
             color: "#68cce0"
             text: "clear"
             horizontalAlignment: Text.AlignHCenter
-            font.pixelSize: 10
+            font.pixelSize: 9
             anchors.bottomMargin: 0
-            font.bold: false
+            font.bold: true
             verticalAlignment: Text.AlignVCenter
             anchors.bottom: parent.top
         }
@@ -612,12 +604,12 @@ Rectangle {
             height: 11
             color: "#68cce0"
             text: "≈"
-            font.bold: false
+            font.bold: true
             anchors.bottom: nButton8.top
             anchors.bottomMargin: 1
             verticalAlignment: Text.AlignVCenter
             horizontalAlignment: Text.AlignHCenter
-            font.pixelSize: 17
+            font.pixelSize: 12
         }
     }
 

--- a/qml/MobileUIFront.qml
+++ b/qml/MobileUIFront.qml
@@ -99,7 +99,7 @@ GridLayout {
         /* Keypad fills right side, as wide as needed */
         PropertyChanges {
             target: controls
-            Layout.minimumWidth: Math.ceil(keypad.width/keypad.height * (mobileui.height - iosmargin.height))
+            Layout.minimumWidth: Math.floor(keypad.width/keypad.height * (mobileui.height - iosmargin.height))
             Layout.maximumWidth: Layout.minimumWidth
             Layout.fillHeight: true
             Layout.columnSpan: 1

--- a/qml/MobileUIFront.qml
+++ b/qml/MobileUIFront.qml
@@ -42,6 +42,8 @@ GridLayout {
 
         Layout.fillHeight: true
         Layout.fillWidth: true
+        Layout.preferredHeight: contentHeight
+        Layout.maximumHeight: contentHeight
         Layout.columnSpan: 2
 
         boundsBehavior: Flickable.StopAtBounds
@@ -70,6 +72,13 @@ GridLayout {
             // This is needed to avoid opening the control center
             height: Qt.platform.os === "ios" ? 20 : 0
         }
+    }
+
+    Rectangle {
+        Layout.fillHeight: true
+        Layout.fillWidth: true
+        Layout.columnSpan: 2
+        color: keypad.color
     }
 
     states: [ State {

--- a/qml/NDualButton.qml
+++ b/qml/NDualButton.qml
@@ -72,9 +72,10 @@ Rectangle {
         color: "#68cce0"
         text: "aa"
         horizontalAlignment: Text.AlignHCenter
-        verticalAlignment: Text.AlignBottom
+        verticalAlignment: Text.AlignVCenter
         z: -1
-        font.pixelSize: 10
+        font.pixelSize: 8
+        font.bold: true
     }
 
     Text {
@@ -86,9 +87,10 @@ Rectangle {
         color: "#68cce0"
         text: "bb"
         horizontalAlignment: Text.AlignHCenter
-        verticalAlignment: Text.AlignBottom
-        font.pixelSize: 10
+        verticalAlignment: Text.AlignVCenter
+        font.pixelSize: 8
         z: -2
+        font.bold: true
     }
 }
 


### PR DESCRIPTION
Most importantly this PR addresses #41, which I was finally able to reproduce on my new phone and on desktop by setting `QT_FONT_DPI=400` (bigger -> more extreme). Beyond that some smaller inconsistencies and graphical issues are fixed. (Spot the changes! :P)

<table>
<tr><th width="50%">Before</th><th width="50%">After</th></tr>
<tr><td colspan="2" align="center">Linux desktop</td></tr>
<tr><td><img src="https://user-images.githubusercontent.com/1622084/197032525-36c8dcd9-c7e5-4d1c-be78-241a8ac1995e.png"/></td><td><img src="https://user-images.githubusercontent.com/1622084/197032734-c5e54fe5-f4c3-4231-96f3-14282b9acbb9.png"/></td></tr>
<tr><td colspan="2" align="center">Linux desktop with QT_FONT_DPI=400 (#41)</td></tr>
<tr><td><img src="https://user-images.githubusercontent.com/1622084/197031178-305a8f90-9da6-46b3-91ca-65d9808e009c.png"/></td><td><img src="https://user-images.githubusercontent.com/1622084/197031207-cfdefd24-50b0-4e4a-9045-ad34f4df1a82.png"/></td></tr>
<tr><td colspan="2" align="center">Android</td></tr>
<tr><td><img src="https://user-images.githubusercontent.com/1622084/197033018-700638ce-63d3-4207-8d2a-79b561cdb36b.png"/></td><td><img src="https://user-images.githubusercontent.com/1622084/197033539-4dec8591-f000-4849-ab06-109d748bca75.png"/></td></tr>
</table>