### PR TITLE
Release pressed keys on FocusOut events

### DIFF
--- a/qml/Keypad.qml
+++ b/qml/Keypad.qml
@@ -333,7 +333,6 @@ Rectangle {
         anchors.leftMargin: 5
         active_color: "#cce"
         back_color: "#bbf"
-        active: false
         font_color: "#222"
     }
 

--- a/qml/NButton.qml
+++ b/qml/NButton.qml
@@ -8,6 +8,8 @@ Rectangle {
     property alias text: label.text
     property bool active: pressed || mouseArea.containsMouse
     property bool pressed: false
+    // Pressing the right mouse button "locks" the button in enabled state
+    property bool fixed: false
     property int keymap_id: 1
 
     signal clicked()
@@ -20,6 +22,9 @@ Rectangle {
     onPressedChanged: {
         if(pressed)
             clicked();
+
+        if(!pressed)
+            fixed = false;
 
         Emu.setButtonState(keymap_id, pressed);
     }
@@ -80,9 +85,6 @@ Rectangle {
         id: mouseArea
 
         enabled: !multiMouseArea.mouseEnabled
-
-        // Pressing the right mouse button "locks" the button in enabled state
-        property bool fixed: false
 
         preventStealing: true
 


### PR DESCRIPTION
Otherwise it's possible that the key is stuck because the KeyRelease event is not received.

Needs some practical testing to check whether this breaks something.