### PR TITLE
Set FD_CLOEXEC on sockets

### DIFF
--- a/core/debug.cpp
+++ b/core/debug.cpp
@@ -635,6 +635,8 @@ static void set_nonblocking(int socket, bool nonblocking) {
 #else
     int ret = fcntl(socket, F_GETFL, 0);
     fcntl(socket, F_SETFL, nonblocking ? ret | O_NONBLOCK : ret & ~O_NONBLOCK);
+    ret = fcntl(socket, F_GETFD, 0);
+    fcntl(socket, F_SETFD, ret | FD_CLOEXEC);
 #endif
 }
 

--- a/core/gdbstub.c
+++ b/core/gdbstub.c
@@ -196,6 +196,8 @@ static void set_nonblocking(int socket, bool nonblocking) {
 #else
     int ret = fcntl(socket, F_GETFL, 0);
     fcntl(socket, F_SETFL, nonblocking ? (ret | O_NONBLOCK) : (ret & ~O_NONBLOCK));
+    ret = fcntl(socket, F_GETFD, 0);
+    fcntl(socket, F_SETFD, ret | FD_CLOEXEC);
 #endif
 }
 


### PR DESCRIPTION
Otherwise any possible child processes inherit those and keep the ports busy.