### PR TITLE
Allow touch events in the keypad widget (#292)

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -39,6 +39,8 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->lcdView->installEventFilter(&qt_keypad_bridge);
     lcd.installEventFilter(&qt_keypad_bridge);
 
+    ui->keypadWidget->setAttribute(Qt::WA_AcceptTouchEvents);
+
     qml_engine = ui->keypadWidget->engine();
     qml_engine->addImportPath(QStringLiteral("qrc:/qml/qml"));
 


### PR DESCRIPTION
The alternative is switching to `QQuickView`, but that's IMO rather risky and I could already hit some weird behaviour with basic testing.