### PR TITLE
[Mobile UI] Introduce separate keypad fill modes (#297)

### DIFF
--- a/qml/ConfigPageEmulation.qml
+++ b/qml/ConfigPageEmulation.qml
@@ -97,7 +97,7 @@ ColumnLayout {
     FBLabel {
         Layout.maximumWidth: parent.width
         wrapMode: Text.WordWrap
-        text: qsTr("Change the side of the keypad in landscape orientation.")
+        text: qsTr("Change the side of the keypad.")
         font.pixelSize: TextMetrics.normalSize
     }
 
@@ -108,6 +108,23 @@ ColumnLayout {
         onCheckedChanged: {
             Emu.leftHanded = checked;
             checked = Qt.binding(function() { return Emu.leftHanded; });
+        }
+    }
+
+    FBLabel {
+        Layout.maximumWidth: parent.width
+        wrapMode: Text.WordWrap
+        text: qsTr("Whether the keypad scrolls vertically in portrait orientation.")
+        font.pixelSize: TextMetrics.normalSize
+    }
+
+    CheckBox {
+        text: qsTr("Scrolling keypad")
+
+        checked: Emu.keypadFillMode === Emu.FillWidth
+        onCheckedChanged: {
+            Emu.keypadFillMode = checked ? Emu.FillWidth : Emu.ResizeToFit
+            checked = Qt.binding(function() { return Emu.keypadFillMode === Emu.FillWidth; });
         }
     }
 

--- a/qml/ConfigPageEmulation.qml
+++ b/qml/ConfigPageEmulation.qml
@@ -92,7 +92,6 @@ ColumnLayout {
         font.pixelSize: TextMetrics.title2Size
         Layout.topMargin: 10
         Layout.bottomMargin: 5
-        visible: Emu.isMobile()
     }
 
     FBLabel {
@@ -100,14 +99,12 @@ ColumnLayout {
         wrapMode: Text.WordWrap
         text: qsTr("Change the side of the keypad in landscape orientation.")
         font.pixelSize: TextMetrics.normalSize
-        visible: Emu.isMobile()
     }
 
     CheckBox {
         text: qsTr("Left-handed mode")
 
         checked: Emu.leftHanded
-        visible: Emu.isMobile()
         onCheckedChanged: {
             Emu.leftHanded = checked;
             checked = Qt.binding(function() { return Emu.leftHanded; });

--- a/qml/MobileUIFront.qml
+++ b/qml/MobileUIFront.qml
@@ -37,6 +37,20 @@ GridLayout {
         }
     }
 
+    Item {
+        visible: Emu.keypadFillMode !== Emu.FillWidth
+        Layout.fillHeight: true
+        Layout.fillWidth: true
+        Layout.columnSpan: 2
+
+        Keypad {
+            id: keypad2
+            x: Emu.leftHanded ? 0 : parent.width - width
+            property double myScale: Math.min(parent.height/height, parent.width/width)
+            transform: Scale { origin.x: Emu.leftHanded ? 0 : keypad2.width; origin.y: 0; xScale: keypad2.myScale; yScale: keypad2.myScale }
+        }
+    }
+
     Flickable {
         id: controls
 
@@ -53,6 +67,7 @@ GridLayout {
         contentHeight: keypad.height*controls.width/keypad.width + iosmargin.height
         clip: true
         pixelAligned: true
+        visible: Emu.keypadFillMode === Emu.FillWidth
 
         Keypad {
             id: keypad
@@ -79,6 +94,7 @@ GridLayout {
         Layout.fillWidth: true
         Layout.columnSpan: 2
         color: keypad.color
+        visible: Emu.keypadFillMode === Emu.FillWidth
     }
 
     states: [ State {

--- a/qmlbridge.cpp
+++ b/qmlbridge.cpp
@@ -198,6 +198,20 @@ void QMLBridge::setDefaultKit(unsigned int id)
     emit defaultKitChanged();
 }
 
+QMLBridge::KeypadFillMode QMLBridge::getKeypadFillMode()
+{
+    return settings.value(QStringLiteral("keypadFillMode"), KeypadFillMode::FillWidth).value<KeypadFillMode>();
+}
+
+void QMLBridge::setKeypadFillMode(KeypadFillMode mode)
+{
+    if(getKeypadFillMode() == mode)
+        return;
+
+    settings.setValue(QStringLiteral("keypadFillMode"), mode);
+    emit keypadFillModeChanged();
+}
+
 bool QMLBridge::getLeftHanded()
 {
     return settings.value(QStringLiteral("leftHanded"), false).toBool();

--- a/qmlbridge.h
+++ b/qmlbridge.h
@@ -13,6 +13,12 @@ public:
     explicit QMLBridge(QObject *parent = 0);
     ~QMLBridge();
 
+    enum KeypadFillMode {
+        FillWidth = 0,
+        ResizeToFit
+    };
+    Q_ENUM(KeypadFillMode);
+
     Q_PROPERTY(unsigned int gdbPort READ getGDBPort WRITE setGDBPort NOTIFY gdbPortChanged)
     Q_PROPERTY(bool gdbEnabled READ getGDBEnabled WRITE setGDBEnabled NOTIFY gdbEnabledChanged)
     Q_PROPERTY(unsigned int rdbPort READ getRDBPort WRITE setRDBPort NOTIFY rdbPortChanged)
@@ -23,6 +29,7 @@ public:
     Q_PROPERTY(bool autostart READ getAutostart WRITE setAutostart NOTIFY autostartChanged)
     Q_PROPERTY(unsigned int defaultKit READ getDefaultKit WRITE setDefaultKit NOTIFY defaultKitChanged)
     Q_PROPERTY(bool leftHanded READ getLeftHanded WRITE setLeftHanded NOTIFY leftHandedChanged)
+    Q_PROPERTY(KeypadFillMode keypadFillMode READ getKeypadFillMode WRITE setKeypadFillMode NOTIFY keypadFillModeChanged)
     Q_PROPERTY(bool suspendOnClose READ getSuspendOnClose WRITE setSuspendOnClose NOTIFY suspendOnCloseChanged)
     Q_PROPERTY(QString usbdir READ getUSBDir WRITE setUSBDir NOTIFY usbDirChanged)
     Q_PROPERTY(QString version READ getVersion CONSTANT)
@@ -55,6 +62,8 @@ public:
     bool getAutostart();
     unsigned int getDefaultKit();
     void setDefaultKit(unsigned int id);
+    KeypadFillMode getKeypadFillMode();
+    void setKeypadFillMode(KeypadFillMode mode);
     bool getLeftHanded();
     void setLeftHanded(bool e);
     bool getSuspendOnClose();
@@ -146,6 +155,7 @@ signals:
     void autostartChanged();
     void defaultKitChanged();
     void leftHandedChanged();
+    void keypadFillModeChanged();
     void suspendOnCloseChanged();
     void usbDirChanged();
     void isRunningChanged();


### PR DESCRIPTION
Allow ResizeToFit in addition to the current mode.

Draft because:

* [ ] Investigate better implementations, this adds another keypad instance
* [ ] Landscape mode not taken into account
* [ ] The keypad widget in the desktop UI could maybe benefit from this as well

![Screenshot_20230107_174230](https://user-images.githubusercontent.com/1622084/211161281-94ea02f3-1b5e-4142-953a-ca74217a934a.png)