### PR TITLE
CI: Move install-qt-action from v3 to v4 and disable setup-python: false for now

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,7 +35,7 @@ jobs:
           add-to-path: false
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@43ec12788e42f375acfcb2cec059edfb9572fbaa # v3
+        uses: jurplel/install-qt-action@f03f05556819ceb3781ee2f455ec44c339d683c0 # v4
         with:
           version: '5.15.2'
           host: 'linux'

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -27,7 +27,8 @@ jobs:
       uses: jurplel/install-qt-action@f03f05556819ceb3781ee2f455ec44c339d683c0 # v4
       with:
           target: desktop
-          setup-python: false
+          # Broken: https://github.com/jurplel/install-qt-action/issues/239
+          # setup-python: false
 
     - name: Build firebird-emu Qt on macOS
       run: |

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -24,7 +24,7 @@ jobs:
         submodules: 'recursive'
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@43ec12788e42f375acfcb2cec059edfb9572fbaa # v3
+      uses: jurplel/install-qt-action@f03f05556819ceb3781ee2f455ec44c339d683c0 # v4
       with:
           target: desktop
           setup-python: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,7 +26,7 @@ jobs:
         submodules: 'recursive'
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@43ec12788e42f375acfcb2cec059edfb9572fbaa # v3
+      uses: jurplel/install-qt-action@f03f05556819ceb3781ee2f455ec44c339d683c0 # v4
       with:
         version: '5.15.2'
         host: 'windows'


### PR DESCRIPTION
Needed to fix macOS build with `setup-python: false`.