### PR TITLE
[AArch64 JIT] Restrict Mach-O specific syntax to __APPLE__

### DIFF
--- a/core/asmcode_aarch64.S
+++ b/core/asmcode_aarch64.S
@@ -1,5 +1,6 @@
+// Mach-O has a different syntax for relocations
 .macro loadsym reg, name
-	#if defined(__clang__) && !defined(ANDROID)
+	#if defined(__APPLE__)
 		adrp \reg, \name\()@PAGE
 		add \reg, \reg, \name\()@PAGEOFF
 	#else


### PR DESCRIPTION
It't not a clang vs. GCC difference but Mach-O vs. ELF.

Alternative to https://github.com/nspire-emus/firebird/pull/381