### PR TITLE
firebird 1.6 CX II touchpad/navigation-pad behavior fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ Download:
 
 * [Latest release](https://github.com/nspire-emus/firebird/releases/latest)
 
+Known issue in Firebird 1.6:
+
+Firebird 1.6 can fail to move the cursor with the CX II touchpad or
+navigation pad even though clicks are visibly registered. This can happen
+with CX II manufacturer data that enables the capTIvate touchpad path. The
+issue was fixed after 1.6 by reading the CX II hardware feature flags from
+`manuf` in big-endian order. If you hit this behavior, use a current master
+build or a release that includes the fix for [#374](https://github.com/nspire-emus/firebird/issues/374)
+merged in [#378](https://github.com/nspire-emus/firebird/pull/378).
+
 Screenshots:
 -------------------
 


### PR DESCRIPTION
﻿## Summary

- Document the Firebird 1.6 CX II touchpad/navigation-pad behavior where clicks can register but the cursor may not move.
- Point affected users to a current master build or a later release containing the CX II `manuf` feature parsing fix from #378.

## Validation

- Ran `git diff --check`.